### PR TITLE
Fully replace Facebook left nav — no collapse, no toggle button

### DIFF
--- a/src/content/dom-injector.ts
+++ b/src/content/dom-injector.ts
@@ -70,7 +70,7 @@ export class DomInjector {
       sidebar.setAttribute("aria-label", "MarketplaceSucks filters and tools");
       sidebar.setAttribute("data-mps-open", "true");
 
-      // Header with toggle back to FB nav
+      // Header
       const header = document.createElement("div");
       header.className = "mps-sidebar-header";
       header.setAttribute("data-mps-part", "sidebar-header");
@@ -79,26 +79,7 @@ export class DomInjector {
       title.className = "mps-sidebar-title";
       title.textContent = "MarketplaceSucks";
 
-      const headerActions = document.createElement("div");
-      headerActions.style.cssText = "display: flex; gap: 4px;";
-
-      const fbNavBtn = document.createElement("button");
-      fbNavBtn.id = "mps-toggle-fb-nav";
-      fbNavBtn.className = "mps-sidebar-close";
-      fbNavBtn.setAttribute("aria-label", "Show Facebook navigation");
-      fbNavBtn.setAttribute("title", "Show Facebook navigation");
-      fbNavBtn.textContent = "\u2630"; // hamburger icon
-
-      const closeBtn = document.createElement("button");
-      closeBtn.className = "mps-sidebar-close";
-      closeBtn.setAttribute("data-mps-action", "close-sidebar");
-      closeBtn.setAttribute("aria-label", "Close sidebar");
-      closeBtn.textContent = "\u00D7";
-
-      headerActions.appendChild(fbNavBtn);
-      headerActions.appendChild(closeBtn);
       header.appendChild(title);
-      header.appendChild(headerActions);
       sidebar.appendChild(header);
 
       // Content area
@@ -234,16 +215,33 @@ export class DomInjector {
    * in a container that's a sibling of the main content area.
    */
   private findFacebookLeftNav(): HTMLElement | null {
-    // The left nav contains "Browse all", "Jobs", "Create new listing" etc.
-    // Find an element that contains these navigation links
+    // Facebook's left column contains "Marketplace" heading, search bar,
+    // "Browse all", "Jobs", "Notifications", categories, etc.
+    // We need to find the outermost container of the entire left column.
+
+    // Strategy 1: Find the "Marketplace" heading text and walk up
+    const allElements = document.querySelectorAll('h1, h2, span, div');
+    for (const el of Array.from(allElements)) {
+      if (el.textContent?.trim() === 'Marketplace' && el.tagName !== 'A') {
+        let parent = el.parentElement;
+        for (let i = 0; i < 15 && parent; i++) {
+          const rect = parent.getBoundingClientRect();
+          // Left column: left edge near 0, width 200-400px, tall
+          if (rect.left < 50 && rect.width > 150 && rect.width < 400 && rect.height > 400) {
+            return parent as HTMLElement;
+          }
+          parent = parent.parentElement;
+        }
+      }
+    }
+
+    // Strategy 2: Find nav links and walk up
     const navLinks = document.querySelectorAll('a[href="/marketplace/"]');
     for (const link of Array.from(navLinks)) {
-      // Walk up to find the nav container
       let parent = link.parentElement;
       for (let i = 0; i < 10 && parent; i++) {
-        // Check if this looks like the left nav container
         const rect = parent.getBoundingClientRect();
-        if (rect.width > 100 && rect.width < 400 && rect.left < 300 && rect.height > 300) {
+        if (rect.left < 50 && rect.width > 150 && rect.width < 400 && rect.height > 400) {
           return parent as HTMLElement;
         }
         parent = parent.parentElement;

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -214,7 +214,6 @@ async function bootstrap(): Promise<void> {
 
     // 5. Inject UI elements FIRST (before loading settings, so sidebar exists
     //    when loadSettings emits SIDEBAR_TOGGLED to restore open state)
-    injector.injectToggleButton();
     injector.injectSidebar();
 
     // 6. Load persisted settings (may emit SIDEBAR_TOGGLED to reopen sidebar)
@@ -314,33 +313,6 @@ async function bootstrap(): Promise<void> {
       if (priceMax) priceMax.value = "";
       if (sortSelect) sortSelect.value = "";
       eventBus.emit(MPS_EVENTS.SETTINGS_CHANGED, { source: "sidebar" });
-    });
-
-    // Wire "show Facebook nav" toggle
-    const fbNavToggle = document.getElementById("mps-toggle-fb-nav");
-    fbNavToggle?.addEventListener("click", () => {
-      eventBus.emit(MPS_EVENTS.SIDEBAR_TOGGLED, { open: false });
-    });
-
-    // Wire toggle button click
-    const toggleBtn = document.getElementById("mps-sidebar-toggle");
-    if (toggleBtn) {
-      toggleBtn.addEventListener("click", () => {
-        const sidebar = document.getElementById("mps-sidebar");
-        if (!sidebar) {
-          injector.injectSidebar();
-        }
-        const isOpen = document.getElementById("mps-sidebar")?.getAttribute("data-mps-open") === "true";
-        eventBus.emit(MPS_EVENTS.SIDEBAR_TOGGLED, { open: !isOpen });
-      });
-    }
-
-    // Wire sidebar close button (delegate on body since sidebar may not exist yet)
-    document.body.addEventListener("click", (e) => {
-      const target = e.target as Element;
-      if (target.closest("[data-mps-action='close-sidebar']")) {
-        eventBus.emit(MPS_EVENTS.SIDEBAR_TOGGLED, { open: false });
-      }
     });
 
     // 6b. Listen for messages from popup/background

--- a/src/content/styles.css
+++ b/src/content/styles.css
@@ -45,7 +45,6 @@
   max-height: 100vh;
   background: var(--mps-sidebar-bg);
   color: var(--mps-sidebar-text);
-  border-right: 1px solid var(--mps-sidebar-border);
   overflow-y: auto;
   overflow-x: hidden;
   font-family: var(--mps-font-family-sans, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif);
@@ -54,21 +53,6 @@
   box-sizing: border-box;
   position: sticky;
   top: 0;
-  transition: width var(--mps-transition-speed) var(--mps-transition-easing),
-              opacity var(--mps-transition-speed) var(--mps-transition-easing);
-}
-
-.mps-sidebar[data-mps-open="false"] {
-  width: 0;
-  overflow: hidden;
-  opacity: 0;
-  padding: 0;
-  border: none;
-}
-
-.mps-sidebar[data-mps-open="true"] {
-  width: var(--mps-sidebar-width);
-  opacity: 1;
 }
 
 .mps-sidebar-header {


### PR DESCRIPTION
When the extension is installed, it completely replaces Facebook's entire left navigation column (Marketplace title, search bar, Browse all, Jobs, Notifications, Categories, etc.) with the MPS sidebar.

Changes from previous approach:
- No floating toggle button (removed entirely)
- No hamburger/close button in header
- No collapsible behavior — sidebar is always visible
- Facebook's left nav is completely hidden
- findFacebookLeftNav improved to find the outermost container including the Marketplace heading and search bar
- Simpler CSS: position:sticky, no width transitions

The sidebar IS the left column. Always present on every Marketplace page. Facebook's original search and nav are replaced.