### PR TITLE
Responsive sidebar width + collapse/expand toggle with icon bar

### DIFF
--- a/src/content/dom-injector.ts
+++ b/src/content/dom-injector.ts
@@ -70,17 +70,36 @@ export class DomInjector {
       sidebar.setAttribute("aria-label", "MarketplaceSucks filters and tools");
       sidebar.setAttribute("data-mps-open", "true");
 
-      // Header
+      // Header with collapse toggle
       const header = document.createElement("div");
       header.className = "mps-sidebar-header";
       header.setAttribute("data-mps-part", "sidebar-header");
+
+      const collapseBtn = document.createElement("button");
+      collapseBtn.id = "mps-collapse-toggle";
+      collapseBtn.className = "mps-collapse-toggle";
+      collapseBtn.setAttribute("aria-label", "Toggle sidebar width");
+      collapseBtn.setAttribute("title", "Collapse / Expand");
+      collapseBtn.innerHTML = "&#x00AB;"; // « chevron
 
       const title = document.createElement("h2");
       title.className = "mps-sidebar-title";
       title.textContent = "MarketplaceSucks";
 
+      header.appendChild(collapseBtn);
       header.appendChild(title);
       sidebar.appendChild(header);
+
+      // Collapsed state icon buttons (visible only when collapsed)
+      const collapsedIcons = document.createElement("div");
+      collapsedIcons.className = "mps-collapsed-icons";
+      collapsedIcons.innerHTML = `
+        <button class="mps-collapsed-icon-btn" title="Search" data-mps-action="expand-search">&#x1F50D;</button>
+        <button class="mps-collapsed-icon-btn" title="Price Filter" data-mps-action="expand-price">&#x1F4B2;</button>
+        <button class="mps-collapsed-icon-btn" title="Sort" data-mps-action="expand-sort">&#x2195;</button>
+        <button class="mps-collapsed-icon-btn" title="Stats" data-mps-action="expand-stats">&#x1F4CA;</button>
+      `;
+      sidebar.appendChild(collapsedIcons);
 
       // Content area
       const content = document.createElement("div");
@@ -191,11 +210,17 @@ export class DomInjector {
       const fbLeftNav = this.findFacebookLeftNav();
       if (fbLeftNav) {
         // Hide Facebook's nav and insert ours in the same position
+        // Match the original nav's width so we fit the same space
+        const fbNavWidth = fbLeftNav.getBoundingClientRect().width;
+        if (fbNavWidth > 100) {
+          sidebar.style.setProperty("--mps-sidebar-width", `${Math.round(fbNavWidth)}px`);
+        }
+
         fbLeftNav.setAttribute("data-mps-original-display", getComputedStyle(fbLeftNav).display);
         fbLeftNav.style.display = "none";
         fbLeftNav.setAttribute("data-mps-hidden-nav", "true");
         fbLeftNav.parentElement?.insertBefore(sidebar, fbLeftNav);
-        console.log("[MPS] Replaced Facebook left nav with MPS controls");
+        console.log(`[MPS] Replaced Facebook left nav (${Math.round(fbNavWidth)}px) with MPS controls`);
       } else {
         // Fallback: append to body as a left-side fixed panel
         document.body.appendChild(sidebar);

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -302,6 +302,29 @@ async function bootstrap(): Promise<void> {
       eventBus.emit(MPS_EVENTS.SETTINGS_CHANGED, { source: "sidebar" });
     });
 
+    // Wire collapse/expand toggle
+    const collapseToggle = document.getElementById("mps-collapse-toggle");
+    collapseToggle?.addEventListener("click", () => {
+      const sidebar = document.getElementById("mps-sidebar");
+      if (sidebar) {
+        const isCollapsed = sidebar.getAttribute("data-mps-collapsed") === "true";
+        sidebar.setAttribute("data-mps-collapsed", String(!isCollapsed));
+        // Update toggle icon: « when expanded, » when collapsed
+        collapseToggle.innerHTML = isCollapsed ? "&#x00AB;" : "&#x00BB;";
+      }
+    });
+
+    // Collapsed icon buttons expand the sidebar when clicked
+    document.querySelectorAll(".mps-collapsed-icon-btn").forEach((btn) => {
+      btn.addEventListener("click", () => {
+        const sidebar = document.getElementById("mps-sidebar");
+        if (sidebar) {
+          sidebar.setAttribute("data-mps-collapsed", "false");
+          if (collapseToggle) collapseToggle.innerHTML = "&#x00AB;";
+        }
+      });
+    });
+
     // Wire clear filters button
     const clearBtn = document.getElementById("mps-clear-filters-btn");
     clearBtn?.addEventListener("click", () => {

--- a/src/content/styles.css
+++ b/src/content/styles.css
@@ -16,7 +16,8 @@
    ========================================================================== */
 
 :root {
-  --mps-sidebar-width: 360px;
+  --mps-sidebar-width: 280px;
+  --mps-sidebar-collapsed-width: 48px;
   --mps-sidebar-bg: var(--mps-color-surface, #ffffff);
   --mps-sidebar-text: var(--mps-color-text-primary, #1c1e21);
   --mps-sidebar-border: var(--mps-color-border, #ced0d4);
@@ -42,6 +43,7 @@
 
 .mps-sidebar {
   width: var(--mps-sidebar-width);
+  min-width: var(--mps-sidebar-width);
   max-height: 100vh;
   background: var(--mps-sidebar-bg);
   color: var(--mps-sidebar-text);
@@ -53,6 +55,76 @@
   box-sizing: border-box;
   position: sticky;
   top: 0;
+  transition: width 0.2s ease, min-width 0.2s ease;
+}
+
+/* Collapsed state — narrow icon bar */
+.mps-sidebar[data-mps-collapsed="true"] {
+  width: var(--mps-sidebar-collapsed-width);
+  min-width: var(--mps-sidebar-collapsed-width);
+}
+
+.mps-sidebar[data-mps-collapsed="true"] .mps-sidebar-content,
+.mps-sidebar[data-mps-collapsed="true"] .mps-sidebar-title {
+  display: none;
+}
+
+.mps-sidebar[data-mps-collapsed="true"] .mps-sidebar-header {
+  flex-direction: column;
+  padding: 8px 4px;
+}
+
+/* Collapse toggle button */
+.mps-collapse-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border: none;
+  border-radius: var(--mps-radius-full, 50%);
+  background: transparent;
+  color: var(--mps-color-text-secondary, #65676b);
+  font-size: 16px;
+  cursor: pointer;
+  transition: background 0.15s;
+  flex-shrink: 0;
+}
+
+.mps-collapse-toggle:hover {
+  background: var(--mps-color-background, #f0f2f5);
+}
+
+/* Collapsed icon buttons */
+.mps-collapsed-icons {
+  display: none;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 0;
+}
+
+.mps-sidebar[data-mps-collapsed="true"] .mps-collapsed-icons {
+  display: flex;
+}
+
+.mps-collapsed-icon-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border: none;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--mps-color-text-secondary, #65676b);
+  font-size: 18px;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.mps-collapsed-icon-btn:hover {
+  background: var(--mps-color-background, #f0f2f5);
 }
 
 .mps-sidebar-header {


### PR DESCRIPTION
1. Dynamic width: sidebar reads the Facebook left nav's actual width before replacing it, sets --mps-sidebar-width to match. The sidebar now fills exactly the same space regardless of browser window size.

2. Collapse/expand toggle (« / » chevron button in header):
   - Expanded: full controls (search, price, sort, stats)
   - Collapsed: narrow 48px icon bar with emoji buttons for Search, Price, Sort, Stats. Clicking any icon expands the sidebar.
   - Smooth CSS transition on width change

3. Default width reduced from 360px to 280px (closer to Facebook's nav width). Overridden dynamically when FB nav width is detected.

4. Collapsed state stored via data-mps-collapsed attribute on sidebar.