### PR TITLE
Wire the orphaned intelligence layer into the running extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Fix Facebook Marketplace's useless search. Real filters. Real sorting. Results you actually asked for.**
 
-MarketplaceSucks is a browser extension that overhauls Facebook Marketplace with 18+ advanced filters, 10 sort options, seller trust scoring, AI image detection, price intelligence, sales forecasting, and a side-by-side comparison engine -- all running **100% locally** with **zero data collection**.
+MarketplaceSucks is a browser extension that overhauls Facebook Marketplace with 18+ advanced filters, 8 sort options, seller trust scoring, AI image detection, price intelligence, sales forecasting, and a side-by-side comparison engine -- all running **100% locally** with **zero data collection**.
 
 No accounts. No API keys. No subscriptions. No data leaves your browser. Ever.
 
@@ -72,7 +72,7 @@ No accounts. No API keys. No subscriptions. No data leaves your browser. Ever.
 
 ### Sorting
 
-10 sort options to put the best results first.
+8 sort options to put the best results first.
 
 | Sort | Default Direction | Missing Data Handling |
 |------|-------------------|----------------------|
@@ -664,7 +664,7 @@ The extension is currently **100% free** and will remain open source. A future P
 | Feature | Free | Pro (Planned) |
 |---------|------|---------------|
 | 18+ filters with fuzzy matching | Yes | Yes |
-| 10 sort options | Yes | Yes |
+| 8 sort options | Yes | Yes |
 | Seller trust scoring (6-factor heuristic) | Yes | Yes |
 | Price intelligence (7-tier statistical) | Yes | Yes |
 | Image detection (heuristic, 5 signals) | Yes | Yes |

--- a/public/manifest.chrome.json
+++ b/public/manifest.chrome.json
@@ -11,16 +11,23 @@
     "notifications"
   ],
   "host_permissions": [
-    "https://www.facebook.com/marketplace/*"
+    "https://www.facebook.com/marketplace/*",
+    "https://*.fbcdn.net/*"
   ],
   "background": {
     "service_worker": "background.js"
   },
   "content_scripts": [
     {
-      "matches": ["https://www.facebook.com/marketplace/*"],
-      "js": ["content.js"],
-      "css": ["assets/content.css"],
+      "matches": [
+        "https://www.facebook.com/marketplace/*"
+      ],
+      "js": [
+        "content.js"
+      ],
+      "css": [
+        "assets/content.css"
+      ],
       "run_at": "document_idle"
     }
   ],

--- a/public/manifest.edge.json
+++ b/public/manifest.edge.json
@@ -6,7 +6,9 @@
   "permissions": [
     "storage",
     "activeTab",
-    "offscreen"
+    "offscreen",
+    "alarms",
+    "notifications"
   ],
   "host_permissions": [
     "https://www.facebook.com/marketplace/*"
@@ -29,6 +31,26 @@
       "32": "assets/icons/icon-32.png",
       "48": "assets/icons/icon-48.png",
       "128": "assets/icons/icon-128.png"
+    }
+  },
+  "commands": {
+    "toggle-sidebar": {
+      "suggested_key": {
+        "default": "Alt+S"
+      },
+      "description": "Toggle MarketplaceSucks sidebar"
+    },
+    "focus-filter": {
+      "suggested_key": {
+        "default": "Alt+F"
+      },
+      "description": "Focus the keyword filter input"
+    },
+    "clear-filters": {
+      "suggested_key": {
+        "default": "Alt+C"
+      },
+      "description": "Clear all active filters"
     }
   },
   "icons": {

--- a/public/manifest.edge.json
+++ b/public/manifest.edge.json
@@ -11,16 +11,23 @@
     "notifications"
   ],
   "host_permissions": [
-    "https://www.facebook.com/marketplace/*"
+    "https://www.facebook.com/marketplace/*",
+    "https://*.fbcdn.net/*"
   ],
   "background": {
     "service_worker": "background.js"
   },
   "content_scripts": [
     {
-      "matches": ["https://www.facebook.com/marketplace/*"],
-      "js": ["content.js"],
-      "css": ["assets/content.css"],
+      "matches": [
+        "https://www.facebook.com/marketplace/*"
+      ],
+      "js": [
+        "content.js"
+      ],
+      "css": [
+        "assets/content.css"
+      ],
       "run_at": "document_idle"
     }
   ],

--- a/public/manifest.firefox.json
+++ b/public/manifest.firefox.json
@@ -38,6 +38,26 @@
       "128": "assets/icons/icon-128.png"
     }
   },
+  "commands": {
+    "toggle-sidebar": {
+      "suggested_key": {
+        "default": "Alt+S"
+      },
+      "description": "Toggle MarketplaceSucks sidebar"
+    },
+    "focus-filter": {
+      "suggested_key": {
+        "default": "Alt+F"
+      },
+      "description": "Focus the keyword filter input"
+    },
+    "clear-filters": {
+      "suggested_key": {
+        "default": "Alt+C"
+      },
+      "description": "Clear all active filters"
+    }
+  },
   "icons": {
     "16": "assets/icons/icon-16.png",
     "32": "assets/icons/icon-32.png",

--- a/public/manifest.firefox.json
+++ b/public/manifest.firefox.json
@@ -16,16 +16,23 @@
     "notifications"
   ],
   "host_permissions": [
-    "https://www.facebook.com/marketplace/*"
+    "https://www.facebook.com/marketplace/*",
+    "https://*.fbcdn.net/*"
   ],
   "background": {
     "service_worker": "background.js"
   },
   "content_scripts": [
     {
-      "matches": ["https://www.facebook.com/marketplace/*"],
-      "js": ["content.js"],
-      "css": ["assets/content.css"],
+      "matches": [
+        "https://www.facebook.com/marketplace/*"
+      ],
+      "js": [
+        "content.js"
+      ],
+      "css": [
+        "assets/content.css"
+      ],
       "run_at": "document_idle"
     }
   ],

--- a/src/background/image-analysis.ts
+++ b/src/background/image-analysis.ts
@@ -15,6 +15,7 @@ import {
   analyzeImageHeuristic,
   isCommonAiResolution,
   isCommonAiAspectRatio,
+  NO_EXIF_SIGNAL,
   type ImageMetadata,
 } from "@/core/analysis/image-analyzer";
 import { computePerceptualHash } from "@/core/analysis/image-fingerprint";
@@ -33,6 +34,30 @@ export interface ImageAnalysisResult {
 
 /** Sample resolution used for saturation / background analysis. */
 const SAMPLE = 64;
+
+/**
+ * Detect whether a JPEG carries an EXIF (APP1) segment by scanning the header.
+ * Reliable enough for the heuristic; non-JPEG formats report false.
+ */
+function jpegHasExif(buffer: ArrayBuffer): boolean {
+  const bytes = new Uint8Array(buffer);
+  if (bytes.length < 4 || bytes[0] !== 0xff || bytes[1] !== 0xd8) return false; // not JPEG
+  let offset = 2;
+  // Walk APPn marker segments looking for APP1 (0xFFE1) "Exif".
+  while (offset + 4 < bytes.length && bytes[offset] === 0xff) {
+    const marker = bytes[offset + 1];
+    const size = (bytes[offset + 2] << 8) + bytes[offset + 3];
+    if (marker === 0xe1) {
+      const e = offset + 4;
+      if (bytes[e] === 0x45 && bytes[e + 1] === 0x78 && bytes[e + 2] === 0x69 && bytes[e + 3] === 0x66) {
+        return true; // "Exif"
+      }
+    }
+    if (marker === 0xda || size <= 0) break; // start of scan / malformed
+    offset += 2 + size;
+  }
+  return false;
+}
 
 /** Compute average + std-dev of per-pixel saturation (HSV) from RGBA data. */
 function saturationStats(data: Uint8ClampedArray): {
@@ -93,7 +118,9 @@ export async function analyzeImageUrl(url: string): Promise<ImageAnalysisResult 
   try {
     const res = await fetch(url);
     if (!res.ok) return null;
-    const blob = await res.blob();
+    const buffer = await res.arrayBuffer();
+    const hasExif = jpegHasExif(buffer);
+    const blob = new Blob([buffer]);
     const bitmap = await createImageBitmap(blob);
     const width = bitmap.width;
     const height = bitmap.height;
@@ -114,10 +141,7 @@ export async function analyzeImageUrl(url: string): Promise<ImageAnalysisResult 
     const metadata: ImageMetadata = {
       width,
       height,
-      // Facebook strips EXIF from every upload, so a missing-EXIF signal would
-      // fire for all images and inflate the score — neutralize it by reporting
-      // EXIF as present and letting the pixel-based signals carry the result.
-      hasExif: true,
+      hasExif,
       hasUniformBackground: hasUniformBackground(data, SAMPLE),
       avgSaturation,
       saturationStdDev,
@@ -125,7 +149,9 @@ export async function analyzeImageUrl(url: string): Promise<ImageAnalysisResult 
       isCommonAiResolution: isCommonAiResolution(width, height),
     };
 
-    const result = analyzeImageHeuristic(metadata);
+    // Facebook strips EXIF from every upload, so the no-EXIF signal carries no
+    // information here — exclude it and renormalize over the pixel-based signals.
+    const result = analyzeImageHeuristic(metadata, { excludeSignals: [NO_EXIF_SIGNAL] });
     return {
       hash,
       aiScore: result.aiScore,

--- a/src/background/image-analysis.ts
+++ b/src/background/image-analysis.ts
@@ -1,0 +1,140 @@
+/**
+ * @module background/image-analysis
+ *
+ * Runs the (previously infeasible) image heuristics for real. Content scripts
+ * can't analyze Facebook's cross-origin CDN images — drawing them to a canvas
+ * taints it. The MV3 service worker, however, can `fetch` the bytes
+ * (CORS-bypassed via `host_permissions` for `*.fbcdn.net`), decode them with
+ * `createImageBitmap`, and read pixels from an `OffscreenCanvas` without taint.
+ *
+ * Given an image URL it returns the perceptual hash + heuristic AI score, which
+ * the content script then persists and surfaces as a badge / in the Images panel.
+ */
+
+import {
+  analyzeImageHeuristic,
+  isCommonAiResolution,
+  isCommonAiAspectRatio,
+  type ImageMetadata,
+} from "@/core/analysis/image-analyzer";
+import { computePerceptualHash } from "@/core/analysis/image-fingerprint";
+
+/** Result returned to the content script for one analyzed image. */
+export interface ImageAnalysisResult {
+  hash: string;
+  /** Heuristic AI score, 0-100. */
+  aiScore: number;
+  classification: string;
+  /** Names of the triggered heuristic signals. */
+  flags: string[];
+  width: number;
+  height: number;
+}
+
+/** Sample resolution used for saturation / background analysis. */
+const SAMPLE = 64;
+
+/** Compute average + std-dev of per-pixel saturation (HSV) from RGBA data. */
+function saturationStats(data: Uint8ClampedArray): {
+  avgSaturation: number;
+  saturationStdDev: number;
+} {
+  const sats: number[] = [];
+  for (let i = 0; i < data.length; i += 4) {
+    const r = data[i] / 255;
+    const g = data[i + 1] / 255;
+    const b = data[i + 2] / 255;
+    const max = Math.max(r, g, b);
+    const min = Math.min(r, g, b);
+    sats.push(max === 0 ? 0 : (max - min) / max);
+  }
+  const avg = sats.reduce((a, b) => a + b, 0) / sats.length;
+  const variance = sats.reduce((a, s) => a + (s - avg) ** 2, 0) / sats.length;
+  return { avgSaturation: avg, saturationStdDev: Math.sqrt(variance) };
+}
+
+/** Heuristic: are the border pixels nearly uniform (solid/studio background)? */
+function hasUniformBackground(data: Uint8ClampedArray, size: number): boolean {
+  const lum: number[] = [];
+  const at = (x: number, y: number): number => {
+    const i = (y * size + x) * 4;
+    return 0.299 * data[i] + 0.587 * data[i + 1] + 0.114 * data[i + 2];
+  };
+  for (let x = 0; x < size; x++) {
+    lum.push(at(x, 0), at(x, size - 1));
+  }
+  for (let y = 1; y < size - 1; y++) {
+    lum.push(at(0, y), at(size - 1, y));
+  }
+  const avg = lum.reduce((a, b) => a + b, 0) / lum.length;
+  const std = Math.sqrt(lum.reduce((a, l) => a + (l - avg) ** 2, 0) / lum.length);
+  return std < 12; // low border variance => uniform background
+}
+
+/** Draw the bitmap into a 32x32 grayscale array (1024 values) for the hash. */
+function toGrayscale32(bitmap: ImageBitmap): number[] {
+  const canvas = new OffscreenCanvas(32, 32);
+  const ctx = canvas.getContext("2d");
+  if (!ctx) throw new Error("2d context unavailable");
+  ctx.drawImage(bitmap, 0, 0, 32, 32);
+  const { data } = ctx.getImageData(0, 0, 32, 32);
+  const gray: number[] = [];
+  for (let i = 0; i < data.length; i += 4) {
+    gray.push(Math.round(0.299 * data[i] + 0.587 * data[i + 1] + 0.114 * data[i + 2]));
+  }
+  return gray;
+}
+
+/**
+ * Fetch, decode and analyze an image URL. Returns null on any failure
+ * (network, decode, unsupported format) — analysis is always best-effort.
+ */
+export async function analyzeImageUrl(url: string): Promise<ImageAnalysisResult | null> {
+  try {
+    const res = await fetch(url);
+    if (!res.ok) return null;
+    const blob = await res.blob();
+    const bitmap = await createImageBitmap(blob);
+    const width = bitmap.width;
+    const height = bitmap.height;
+
+    const canvas = new OffscreenCanvas(SAMPLE, SAMPLE);
+    const ctx = canvas.getContext("2d");
+    if (!ctx) {
+      bitmap.close();
+      return null;
+    }
+    ctx.drawImage(bitmap, 0, 0, SAMPLE, SAMPLE);
+    const { data } = ctx.getImageData(0, 0, SAMPLE, SAMPLE);
+
+    const { avgSaturation, saturationStdDev } = saturationStats(data);
+    const hash = computePerceptualHash(toGrayscale32(bitmap));
+    bitmap.close();
+
+    const metadata: ImageMetadata = {
+      width,
+      height,
+      // Facebook strips EXIF from every upload, so a missing-EXIF signal would
+      // fire for all images and inflate the score — neutralize it by reporting
+      // EXIF as present and letting the pixel-based signals carry the result.
+      hasExif: true,
+      hasUniformBackground: hasUniformBackground(data, SAMPLE),
+      avgSaturation,
+      saturationStdDev,
+      isCommonAiAspectRatio: isCommonAiAspectRatio(width, height),
+      isCommonAiResolution: isCommonAiResolution(width, height),
+    };
+
+    const result = analyzeImageHeuristic(metadata);
+    return {
+      hash,
+      aiScore: result.aiScore,
+      classification: result.classification,
+      flags: result.signals.filter((s) => s.triggered).map((s) => s.name),
+      width,
+      height,
+    };
+  } catch {
+    return null;
+  }
+}

--- a/src/background/service-worker.ts
+++ b/src/background/service-worker.ts
@@ -7,6 +7,7 @@
  */
 
 import { browser } from '@/platform/browser';
+import { analyzeImageUrl } from '@/background/image-analysis';
 
 /** Message types for inter-component communication */
 interface ExtensionMessage {
@@ -109,6 +110,12 @@ browser.runtime.onMessage.addListener(
           }
           return undefined;
         });
+
+      case 'analyze-image': {
+        const payload = msg.payload as { url?: string } | undefined;
+        if (!payload?.url) return Promise.resolve(null);
+        return analyzeImageUrl(payload.url);
+      }
 
       case 'open-marketplace':
         return browser.tabs.create({

--- a/src/background/service-worker.ts
+++ b/src/background/service-worker.ts
@@ -162,6 +162,7 @@ async function checkAlerts(): Promise<void> {
     'mps-price-history',
     'mps-last-alert-check',
     'mps-notification-badge-count',
+    'mps-notification-urls',
   ]);
 
   const data = result as Record<string, unknown>;
@@ -215,15 +216,18 @@ async function checkAlerts(): Promise<void> {
     }
   }
 
-  // Show browser notifications
+  // Show browser notifications, remembering each one's target URL so a click
+  // can open the right listing.
+  const urlMap: Record<string, string> = {};
   for (const n of notifications) {
     try {
       await browser.notifications?.create(n.id, {
         type: 'basic',
         title: n.title,
         message: n.body,
-        iconUrl: browser.runtime.getURL('icon-128.png'),
+        iconUrl: browser.runtime.getURL('assets/icons/icon-128.png'),
       });
+      if (n.url) urlMap[n.id] = n.url;
       badgeCount++;
     } catch (err) {
       console.warn('[MPS] Failed to create notification:', err);
@@ -240,9 +244,19 @@ async function checkAlerts(): Promise<void> {
     }
   }
 
+  // Merge new click-URLs into the persisted map (keep recent entries bounded).
+  const existingUrls = (data['mps-notification-urls'] ?? {}) as Record<string, string>;
+  const mergedUrls = { ...existingUrls, ...urlMap };
+  const urlEntries = Object.entries(mergedUrls);
+  const boundedUrls = Object.fromEntries(urlEntries.slice(-200));
+
   await browser.storage.local.set({
     'mps-last-alert-check': Date.now(),
     'mps-notification-badge-count': badgeCount,
+    'mps-notification-urls': boundedUrls,
+    // Price-drop entries are consumed once notified, so clear them to avoid
+    // re-notifying the same drop on every subsequent check.
+    'mps-price-history': [],
   });
 
   if (notifications.length > 0) {

--- a/src/content/analysis-runner.test.ts
+++ b/src/content/analysis-runner.test.ts
@@ -9,6 +9,7 @@ import { analyzeListing, analyzeListings } from "@/content/analysis-runner";
 function fakeSource(opts: {
   comparables?: number[];
   previousEngagement?: EngagementSnapshot | null;
+  sellerTrustScore?: number | null;
 }): AnalysisDataSource {
   return {
     async getComparablePrices() {
@@ -16,6 +17,9 @@ function fakeSource(opts: {
     },
     async getPreviousEngagement() {
       return opts.previousEngagement ?? null;
+    },
+    async getSellerTrustScore() {
+      return opts.sellerTrustScore ?? null;
     },
   };
 }

--- a/src/content/analysis-runner.test.ts
+++ b/src/content/analysis-runner.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from "vitest";
+import { createListing } from "@/core/models/listing";
+import type { Listing } from "@/core/models/listing";
+import type { EngagementSnapshot } from "@/data/db-schema";
+import type { AnalysisDataSource } from "@/content/persistence";
+import { analyzeListing, analyzeListings } from "@/content/analysis-runner";
+
+/** Build a configurable in-memory data source for the analysis runner. */
+function fakeSource(opts: {
+  comparables?: number[];
+  previousEngagement?: EngagementSnapshot | null;
+}): AnalysisDataSource {
+  return {
+    async getComparablePrices() {
+      return opts.comparables ?? [];
+    },
+    async getPreviousEngagement() {
+      return opts.previousEngagement ?? null;
+    },
+  };
+}
+
+function makeListing(over: Partial<Parameters<typeof createListing>[0]> = {}): Listing {
+  return createListing({
+    id: "1",
+    title: "Vintage Record Player",
+    listingUrl: "https://facebook.com/marketplace/item/1",
+    category: "Electronics",
+    ...over,
+  });
+}
+
+describe("analyzeListing — price rating", () => {
+  it("attaches a price rating tier and score when enough comparables exist", async () => {
+    // median of [100,110,120,130,140] = 120; listing at 60 => 50% of median
+    const listing = makeListing({ price: 60 });
+    const source = fakeSource({ comparables: [100, 110, 120, 130, 140] });
+
+    const result = await analyzeListing(listing, source);
+
+    expect(result.priceRating).toBeDefined();
+    expect(result.priceRatingScore).toBe(50);
+  });
+
+  it("does not attach a rating with fewer than 5 comparables", async () => {
+    const listing = makeListing({ price: 60 });
+    const source = fakeSource({ comparables: [100, 120, 140] });
+
+    const result = await analyzeListing(listing, source);
+
+    expect(result.priceRating).toBeUndefined();
+    expect(result.priceRatingScore).toBeUndefined();
+  });
+
+  it("does not attach a rating when the listing has no price", async () => {
+    const listing = makeListing({ price: null });
+    const source = fakeSource({ comparables: [100, 110, 120, 130, 140] });
+
+    const result = await analyzeListing(listing, source);
+
+    expect(result.priceRating).toBeUndefined();
+  });
+});
+
+describe("analyzeListing — heat", () => {
+  it("attaches a heat score when the listing has engagement", async () => {
+    const listing = makeListing({
+      engagement: { saves: 20, comments: 5, views: 400 },
+      parsedDate: Date.now(),
+    });
+    const source = fakeSource({});
+
+    const result = await analyzeListing(listing, source);
+
+    expect(result.heatScore).toBeGreaterThan(0);
+  });
+
+  it("does not attach a heat score when there is no engagement data", async () => {
+    const listing = makeListing({ price: 100 });
+    const source = fakeSource({ comparables: [90, 100, 110, 120, 130] });
+
+    const result = await analyzeListing(listing, source);
+
+    expect(result.heatScore).toBeUndefined();
+  });
+});
+
+describe("analyzeListing — forecast", () => {
+  it("attaches an estimated days-to-sell when comparables exist", async () => {
+    const listing = makeListing({ price: 80 });
+    const source = fakeSource({ comparables: [100, 110, 120, 130, 140] });
+
+    const result = await analyzeListing(listing, source);
+
+    expect(result.estimatedDaysToSell).toBeGreaterThan(0);
+    expect(result.estimatedDaysToSell).toBeLessThanOrEqual(90);
+  });
+});
+
+describe("analyzeListing — purity", () => {
+  it("does not mutate the original listing", async () => {
+    const listing = makeListing({ price: 60 });
+    const source = fakeSource({ comparables: [100, 110, 120, 130, 140] });
+
+    await analyzeListing(listing, source);
+
+    expect("priceRating" in listing).toBe(false);
+  });
+});
+
+describe("analyzeListings — batch", () => {
+  it("analyzes every listing and preserves order", async () => {
+    const listings = [
+      makeListing({ id: "a", price: 60 }),
+      makeListing({ id: "b", price: 200 }),
+    ];
+    const source = fakeSource({ comparables: [100, 110, 120, 130, 140] });
+
+    const results = await analyzeListings(listings, source);
+
+    expect(results.map((r) => r.id)).toEqual(["a", "b"]);
+    expect(results[0].priceRating).toBeDefined();
+    expect(results[1].priceRating).toBeDefined();
+  });
+});

--- a/src/content/analysis-runner.ts
+++ b/src/content/analysis-runner.ts
@@ -70,11 +70,19 @@ export async function analyzeListing(
 ): Promise<AnalyzedListing> {
   const fields: AnalysisFields = {};
 
-  // --- Seller trust (only meaningful when profile factors are available) ---
+  // --- Seller trust ---
+  // Detail-page flow: a full profile was passed -> score it fresh.
+  // Grid flow: look up the trust score cached when the seller's detail page
+  // was last visited (keyed by profile URL).
   if (sellerProfile) {
     const trust = calculateTrustScore(sellerProfile);
     if (trust.confidence !== "insufficient") {
       fields.sellerTrustScore = trust.score;
+    }
+  } else if (listing.sellerProfileUrl) {
+    const cached = await dataSource.getSellerTrustScore(listing.sellerProfileUrl);
+    if (cached !== null) {
+      fields.sellerTrustScore = cached;
     }
   }
 
@@ -97,16 +105,28 @@ export async function analyzeListing(
   }
 
   // --- Heat (needs engagement; velocity needs a previous snapshot) ---
+  // Grid cards rarely expose engagement, but if the listing's detail page was
+  // visited we have a persisted snapshot to fall back on.
   let heatScore: number | null = null;
-  if (hasEngagement(listing)) {
-    const previous = await dataSource.getPreviousEngagement(listing.id);
+  let engagement = {
+    saves: listing.engagement.saves,
+    comments: listing.engagement.comments,
+    views: listing.engagement.views,
+  };
+  let previous = hasEngagement(listing)
+    ? toPreviousEngagement(await dataSource.getPreviousEngagement(listing.id))
+    : undefined;
+  if (!hasEngagement(listing)) {
+    const stored = await dataSource.getPreviousEngagement(listing.id);
+    if (stored && (stored.saves !== null || stored.comments !== null || stored.views !== null)) {
+      engagement = { saves: stored.saves, comments: stored.comments, views: stored.views };
+      previous = undefined; // single snapshot -> no velocity baseline
+    }
+  }
+  if (engagement.saves !== null || engagement.comments !== null || engagement.views !== null) {
     const heat = calculateHeatScore({
-      engagement: {
-        saves: listing.engagement.saves,
-        comments: listing.engagement.comments,
-        views: listing.engagement.views,
-      },
-      previousEngagement: toPreviousEngagement(previous),
+      engagement,
+      previousEngagement: previous,
       searchPosition: null,
       postedDate: listing.parsedDate !== null ? new Date(listing.parsedDate) : null,
     });

--- a/src/content/analysis-runner.ts
+++ b/src/content/analysis-runner.ts
@@ -1,0 +1,165 @@
+/**
+ * @module content/analysis-runner
+ *
+ * Turns plain parsed {@link Listing}s into {@link AnalyzedListing}s by invoking
+ * the (previously orphaned) analysis modules with data read back from the
+ * persistence layer.
+ *
+ * This is the seam that connects `core/analysis/*` to the running extension.
+ * Each analyzer is fed exactly the inputs it documents:
+ *
+ *  - **Price rating** compares the listing price against comparable prices
+ *    accumulated in IndexedDB (needs 5+ comparables, else no rating).
+ *  - **Heat** compares current engagement against the previous snapshot.
+ *  - **Sales forecast** combines the price ratio + heat into a days-to-sell
+ *    estimate once enough comparable data exists.
+ *  - **Seller trust** is computed when seller-profile data is available
+ *    (typically only on the detail page, not the search grid).
+ *
+ * The runner depends only on an {@link AnalysisDataSource}, so it is fully
+ * unit-testable with an in-memory fake -- no IndexedDB required.
+ */
+
+import type { Listing } from "@/core/models/listing";
+import type { AnalyzedListing } from "@/core/models/analyzed-listing";
+import type { SellerProfile } from "@/core/models/seller";
+import type { EngagementSnapshot } from "@/data/db-schema";
+import type { AnalysisDataSource } from "@/content/persistence";
+import { calculateTrustScore } from "@/core/analysis/seller-trust";
+import { rateListing } from "@/core/analysis/price-rater";
+import { calculateHeatScore } from "@/core/analysis/heat-tracker";
+import { forecastSale } from "@/core/analysis/sales-forecaster";
+
+/** Mutable accumulator for analysis fields before freezing into AnalyzedListing. */
+type AnalysisFields = {
+  sellerTrustScore?: number;
+  priceRating?: string;
+  priceRatingScore?: number;
+  heatScore?: number;
+  estimatedDaysToSell?: number;
+};
+
+/** Does this listing carry any engagement signal worth scoring for heat? */
+function hasEngagement(listing: Listing): boolean {
+  const { saves, comments, views } = listing.engagement;
+  return saves !== null || comments !== null || views !== null;
+}
+
+/** Map a persisted snapshot to the heat tracker's previous-engagement shape. */
+function toPreviousEngagement(
+  snapshot: EngagementSnapshot | null,
+): { saves: number | null; comments: number | null; views: number | null; observedAt: string } | undefined {
+  if (!snapshot) return undefined;
+  return {
+    saves: snapshot.saves,
+    comments: snapshot.comments,
+    views: snapshot.views,
+    observedAt: snapshot.observedAt,
+  };
+}
+
+/**
+ * Analyze a single listing, returning a new {@link AnalyzedListing}. The
+ * original listing is never mutated; only fields backed by real data are
+ * attached (so sorters/filters correctly treat the rest as "no data").
+ */
+export async function analyzeListing(
+  listing: Listing,
+  dataSource: AnalysisDataSource,
+  sellerProfile?: Partial<SellerProfile>,
+): Promise<AnalyzedListing> {
+  const fields: AnalysisFields = {};
+
+  // --- Seller trust (only meaningful when profile factors are available) ---
+  if (sellerProfile) {
+    const trust = calculateTrustScore(sellerProfile);
+    if (trust.confidence !== "insufficient") {
+      fields.sellerTrustScore = trust.score;
+    }
+  }
+
+  // --- Price rating (the grid's primary working signal) ---
+  let median: number | null = null;
+  if (listing.price !== null && listing.price > 0) {
+    const comparablePrices = await dataSource.getComparablePrices(listing);
+    const rating = rateListing({
+      price: listing.price,
+      condition: listing.condition === "unknown" ? null : listing.condition,
+      comparablePrices,
+      category: listing.category,
+      dataWindowDays: 30,
+    });
+    if (rating) {
+      fields.priceRating = rating.tier;
+      fields.priceRatingScore = rating.percentOfMedian;
+      median = rating.stats.median;
+    }
+  }
+
+  // --- Heat (needs engagement; velocity needs a previous snapshot) ---
+  let heatScore: number | null = null;
+  if (hasEngagement(listing)) {
+    const previous = await dataSource.getPreviousEngagement(listing.id);
+    const heat = calculateHeatScore({
+      engagement: {
+        saves: listing.engagement.saves,
+        comments: listing.engagement.comments,
+        views: listing.engagement.views,
+      },
+      previousEngagement: toPreviousEngagement(previous),
+      searchPosition: null,
+      postedDate: listing.parsedDate !== null ? new Date(listing.parsedDate) : null,
+    });
+    heatScore = heat.score;
+    fields.heatScore = heat.score;
+  }
+
+  // --- Sales forecast (reuses the price-rating comparables + heat) ---
+  if (listing.price !== null && listing.price > 0 && median !== null) {
+    // We don't track sell-through times, so the category data points are the
+    // price comparables and the base falls back to the forecaster's default.
+    const comparablePrices = await dataSource.getComparablePrices(listing);
+    const forecast = forecastSale({
+      categoryAvgDays: null,
+      categoryDataPoints: comparablePrices.length,
+      priceRatio: median > 0 ? listing.price / median : null,
+      heatScore,
+      condition: listing.condition === "unknown" ? null : listing.condition,
+      price: listing.price,
+      isWeekendListing: isWeekend(listing.parsedDate),
+      isResponsiveSeller: false,
+    });
+    if (forecast) {
+      fields.estimatedDaysToSell = forecast.estimatedDays;
+    }
+  }
+
+  return { ...listing, ...fields };
+}
+
+/** Whether a posted-date timestamp falls on a weekend. */
+function isWeekend(parsedDate: number | null): boolean {
+  if (parsedDate === null) return false;
+  const day = new Date(parsedDate).getDay();
+  return day === 0 || day === 6;
+}
+
+/**
+ * Analyze a batch of listings. Returns a new array of {@link AnalyzedListing}s
+ * in the same order. Best-effort: a failure on one listing yields the
+ * un-enriched listing rather than dropping it.
+ */
+export async function analyzeListings(
+  listings: Listing[],
+  dataSource: AnalysisDataSource,
+): Promise<AnalyzedListing[]> {
+  return Promise.all(
+    listings.map(async (listing) => {
+      try {
+        return await analyzeListing(listing, dataSource);
+      } catch {
+        return listing as AnalyzedListing;
+      }
+    }),
+  );
+}

--- a/src/content/badge-builder.test.ts
+++ b/src/content/badge-builder.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { createListing } from "@/core/models/listing";
+import type { AnalyzedListing } from "@/core/models/analyzed-listing";
+import { buildBadges } from "@/content/badge-builder";
+
+function analyzed(fields: Partial<AnalyzedListing>): AnalyzedListing {
+  const base = createListing({
+    id: "1",
+    title: "Item",
+    listingUrl: "https://facebook.com/marketplace/item/1",
+  });
+  return { ...base, ...fields };
+}
+
+describe("buildBadges", () => {
+  it("returns no badges for an un-analyzed listing", () => {
+    expect(buildBadges(analyzed({}))).toEqual([]);
+  });
+
+  it("builds a price badge mapped to the correct CSS level", () => {
+    const badges = buildBadges(analyzed({ priceRating: "great-deal", priceRatingScore: 60 }));
+    const price = badges.find((b) => b.type === "price");
+    expect(price?.level).toBe("great");
+    expect(price?.label).toContain("Great Deal");
+    expect(price?.tooltip).toContain("60% of median");
+  });
+
+  it("builds a trust badge with the right tier level", () => {
+    expect(buildBadges(analyzed({ sellerTrustScore: 85 }))[0]).toMatchObject({
+      type: "trust",
+      level: "high",
+    });
+    expect(buildBadges(analyzed({ sellerTrustScore: 30 }))[0].level).toBe("low");
+  });
+
+  it("only shows a heat badge at warm and above", () => {
+    expect(buildBadges(analyzed({ heatScore: 10 })).some((b) => b.type === "heat")).toBe(false);
+    expect(buildBadges(analyzed({ heatScore: 85 }))[0]).toMatchObject({
+      type: "heat",
+      level: "fire",
+    });
+  });
+
+  it("builds a forecast badge with urgency level", () => {
+    expect(buildBadges(analyzed({ estimatedDaysToSell: 1.4 }))[0]).toMatchObject({
+      type: "forecast",
+      level: "fast",
+    });
+    expect(buildBadges(analyzed({ estimatedDaysToSell: 30 }))[0].level).toBe("slow");
+  });
+
+  it("orders badges price, trust, heat, forecast", () => {
+    const badges = buildBadges(
+      analyzed({
+        priceRating: "steal",
+        priceRatingScore: 30,
+        sellerTrustScore: 90,
+        heatScore: 70,
+        estimatedDaysToSell: 2,
+      }),
+    );
+    expect(badges.map((b) => b.type)).toEqual(["price", "trust", "heat", "forecast"]);
+  });
+});

--- a/src/content/badge-builder.ts
+++ b/src/content/badge-builder.ts
@@ -1,0 +1,115 @@
+/**
+ * @module content/badge-builder
+ *
+ * Pure mapping from an {@link AnalyzedListing} to the {@link BadgeDescriptor}s
+ * rendered on its Facebook listing card by {@link DomInjector.injectBadge}.
+ *
+ * Kept side-effect-free (no DOM access) so it can be unit-tested directly. The
+ * CSS classes referenced here (`mps-badge-<type>-<level>`) are defined in
+ * `content/styles.css`.
+ *
+ * Only fields backed by real analysis data produce a badge; an un-analyzed
+ * listing yields an empty array, so cards stay clean until data is available.
+ */
+
+import type { AnalyzedListing } from "@/core/models/analyzed-listing";
+import type { BadgeDescriptor } from "@/content/dom-injector";
+import { PRICE_RATING_INFO } from "@/core/analysis/price-rater";
+import type { PriceRatingTier } from "@/core/analysis/price-rater";
+
+/** Map a 0-100 trust score to its badge level (matches CSS class suffixes). */
+function trustLevel(score: number): string {
+  if (score >= 80) return "high";
+  if (score >= 60) return "moderate";
+  if (score >= 40) return "caution";
+  return "low";
+}
+
+/** Map a 0-100 heat score to its badge level, or `null` below the warm cutoff. */
+function heatLevel(score: number): "warm" | "hot" | "fire" | null {
+  if (score >= 80) return "fire";
+  if (score >= 60) return "hot";
+  if (score >= 30) return "warm";
+  return null;
+}
+
+/** Map an estimated days-to-sell to an urgency badge level. */
+function forecastLevel(days: number): "fast" | "moderate" | "slow" {
+  if (days <= 2) return "fast";
+  if (days <= 7) return "moderate";
+  return "slow";
+}
+
+/**
+ * Build the list of badges to render on a listing card from its analysis
+ * results. Order: price, trust, heat, forecast, image.
+ */
+export function buildBadges(listing: AnalyzedListing): BadgeDescriptor[] {
+  const badges: BadgeDescriptor[] = [];
+
+  // Price rating
+  if (listing.priceRating) {
+    const info = PRICE_RATING_INFO[listing.priceRating as PriceRatingTier];
+    if (info) {
+      const pct = listing.priceRatingScore;
+      badges.push({
+        type: "price",
+        level: info.color.replace("price-", ""),
+        label: `${info.emoji} ${info.label}`.trim(),
+        tooltip:
+          pct !== undefined
+            ? `${info.description} (${pct}% of median)`
+            : info.description,
+      });
+    }
+  }
+
+  // Seller trust
+  if (listing.sellerTrustScore !== undefined) {
+    const score = Math.round(listing.sellerTrustScore);
+    badges.push({
+      type: "trust",
+      level: trustLevel(score),
+      label: `Trust ${score}`,
+      tooltip: `Seller trust score ${score}/100`,
+    });
+  }
+
+  // Heat (only warm and above)
+  if (listing.heatScore !== undefined) {
+    const level = heatLevel(listing.heatScore);
+    if (level) {
+      const label =
+        level === "fire" ? "On Fire" : level === "hot" ? "Hot" : "Warm";
+      badges.push({
+        type: "heat",
+        level,
+        label: `\u{1F525} ${label}`,
+        tooltip: `Heat score ${Math.round(listing.heatScore)}/100`,
+      });
+    }
+  }
+
+  // Sales forecast
+  if (listing.estimatedDaysToSell !== undefined) {
+    const days = listing.estimatedDaysToSell;
+    badges.push({
+      type: "forecast",
+      level: forecastLevel(days),
+      label: days < 1 ? "Sells <1d" : `Sells ~${Math.round(days)}d`,
+      tooltip: `Estimated ${days.toFixed(1)} days to sell`,
+    });
+  }
+
+  // Image flags (populated once image analysis runs)
+  if (listing.imageFlags && listing.imageFlags.length > 0) {
+    badges.push({
+      type: "image",
+      level: "low",
+      label: "⚠ Image",
+      tooltip: listing.imageFlags.join(", "),
+    });
+  }
+
+  return badges;
+}

--- a/src/content/detail-page-enhancer.ts
+++ b/src/content/detail-page-enhancer.ts
@@ -39,6 +39,17 @@ export class DetailPageEnhancer {
   /** Whether the enhancer is currently active. */
   private active = false;
 
+  /**
+   * Optional callback invoked once a detail page's content has loaded, with
+   * the listing id. Used by the content script to parse seller/engagement data
+   * (only available on detail pages) and persist it for grid enrichment.
+   */
+  private readonly onDetailReady?: (listingId: string) => void;
+
+  constructor(onDetailReady?: (listingId: string) => void) {
+    this.onDetailReady = onDetailReady;
+  }
+
   /** The current detail page listing ID, or `null` if not on a detail page. */
   private currentListingId: string | null = null;
 
@@ -214,6 +225,9 @@ export class DetailPageEnhancer {
     try {
       this.injectRelatedListings(listingId);
       this.injectPriceAnalysis(listingId);
+      // Let the content script parse + persist seller/engagement data that is
+      // only present on detail pages.
+      this.onDetailReady?.(listingId);
     } catch (err) {
       console.warn("[MPS] Error injecting detail page enhancements:", err);
     }

--- a/src/content/detail-page-parser.test.ts
+++ b/src/content/detail-page-parser.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import { JSDOM } from "jsdom";
+import {
+  extractSellerProfile,
+  extractDetailEngagement,
+  buildSellerRecord,
+} from "@/content/detail-page-parser";
+
+const SELLER_HTML = `
+  <div data-testid="marketplace-pdp-seller-info">
+    <a href="/marketplace/profile/200001/">
+      <img src="https://scontent.xx.fbcdn.net/seller.jpg" alt="Jane D." />
+    </a>
+    <span>Joined Facebook in 2018</span>
+    <span>Very responsive</span>
+    <span>4.8 stars (23 reviews)</span>
+  </div>
+  <div data-testid="marketplace-pdp-engagement">
+    <span>12 people saved this</span>
+    <span>3 comments</span>
+    <span>156 views</span>
+  </div>`;
+
+function docFrom(html: string): Document {
+  return new JSDOM(`<html><body>${html}</body></html>`).window.document;
+}
+
+describe("extractSellerProfile", () => {
+  it("parses seller fields from a detail page", () => {
+    const parsed = extractSellerProfile(docFrom(SELLER_HTML), "Brooklyn, NY");
+    expect(parsed).not.toBeNull();
+    expect(parsed?.id).toBe("200001");
+    expect(parsed?.displayName).toBe("Jane D.");
+    expect(parsed?.profileUrl).toContain("/marketplace/profile/200001/");
+    expect(parsed?.profileImageUrl).toContain("seller.jpg");
+    expect(parsed?.ratingOverall).toBe(4.8);
+    expect(parsed?.ratingCount).toBe(23);
+    expect(parsed?.responseText?.toLowerCase()).toContain("responsive");
+    expect(parsed?.accountAgeDays).toBeGreaterThan(0);
+    expect(parsed?.location).toBe("Brooklyn, NY");
+  });
+
+  it("returns null when no seller block is present", () => {
+    expect(extractSellerProfile(docFrom("<div>nothing</div>"))).toBeNull();
+  });
+});
+
+describe("extractDetailEngagement", () => {
+  it("parses saves/comments/views", () => {
+    expect(extractDetailEngagement(docFrom(SELLER_HTML))).toEqual({
+      saves: 12,
+      comments: 3,
+      views: 156,
+    });
+  });
+
+  it("returns null when no engagement block is present", () => {
+    expect(extractDetailEngagement(docFrom("<div>nope</div>"))).toBeNull();
+  });
+});
+
+describe("buildSellerRecord", () => {
+  it("computes a trust score and a persisted record", () => {
+    const parsed = extractSellerProfile(docFrom(SELLER_HTML), "Brooklyn, NY")!;
+    const record = buildSellerRecord(parsed);
+
+    expect(record.id).toBe("200001");
+    expect(record.rating).toBe(4.8);
+    expect(record.ratingCount).toBe(23);
+    expect(record.hasProfilePhoto).toBe(true);
+    expect(record.hasLocation).toBe(true);
+    // 3+ real factors (age, rating, volume, completeness, response) => a solid score.
+    expect(record.trustScore).toBeGreaterThanOrEqual(60);
+    expect(record.trustScoreBreakdown.rating).toBeGreaterThan(0);
+  });
+});

--- a/src/content/detail-page-parser.ts
+++ b/src/content/detail-page-parser.ts
@@ -1,0 +1,172 @@
+/**
+ * @module content/detail-page-parser
+ *
+ * Parses the seller-profile and engagement data that Facebook only renders on a
+ * listing's **detail page** (not on the search grid). This is what lets the
+ * Trust and Heat features light up: once a seller has been scored from a visited
+ * detail page, grid listings from that same seller pick up the cached score.
+ *
+ * The DOM-reading functions are isolated here (using detail-page-specific
+ * `data-testid` blocks) so they don't touch the health-monitored grid selectors
+ * in `selectors.config.ts`. `buildSellerRecord` is pure and unit-tested.
+ */
+
+import { calculateTrustScore } from "@/core/analysis/seller-trust";
+import type { SellerProfile as DomainSellerProfile } from "@/core/models/seller";
+import type { SellerProfile as SellerRecord } from "@/data/db-schema";
+
+/** Raw seller fields scraped from a detail page, before scoring. */
+export interface ParsedSellerProfile {
+  id: string;
+  displayName: string;
+  profileUrl: string;
+  profileImageUrl: string | null;
+  joinedDate: string | null;
+  accountAgeDays: number | null;
+  ratingOverall: number | null;
+  ratingCount: number | null;
+  responseText: string | null;
+  location: string | null;
+  activeListings: number | null;
+}
+
+/** First non-empty number found in a string, or null. */
+function firstNumber(text: string): number | null {
+  const m = text.replace(/,/g, "").match(/\d+(\.\d+)?/);
+  return m ? Number(m[0]) : null;
+}
+
+/**
+ * Extract a seller profile from a detail page. Returns null if the seller-info
+ * block is absent. `fallbackLocation` (the listing's location) is used for the
+ * profile-completeness "has location" signal when the block omits it.
+ */
+export function extractSellerProfile(
+  root: ParentNode,
+  fallbackLocation: string | null = null,
+): ParsedSellerProfile | null {
+  const block =
+    root.querySelector('[data-testid="marketplace-pdp-seller-info"]') ??
+    root.querySelector('[data-testid*="seller-info"]');
+  if (!block) return null;
+
+  const link = block.querySelector<HTMLAnchorElement>('a[href*="/marketplace/profile/"]');
+  const href = link?.getAttribute("href") ?? "";
+  const idMatch = href.match(/\/marketplace\/profile\/(\d+)/);
+  if (!idMatch) return null;
+  const id = idMatch[1];
+  const profileUrl = href.startsWith("http") ? href : `https://www.facebook.com${href}`;
+
+  const img = block.querySelector<HTMLImageElement>("img");
+  const profileImageUrl = img?.getAttribute("src") ?? null;
+
+  const spans = Array.from(block.querySelectorAll("span")).map((s) => s.textContent?.trim() ?? "");
+  const displayName =
+    img?.getAttribute("alt")?.trim() || spans.find((t) => t.length > 0) || "Unknown seller";
+
+  let joinedDate: string | null = null;
+  let accountAgeDays: number | null = null;
+  let ratingOverall: number | null = null;
+  let ratingCount: number | null = null;
+  let responseText: string | null = null;
+
+  for (const text of spans) {
+    const lower = text.toLowerCase();
+    if (lower.includes("joined")) {
+      joinedDate = text;
+      const year = text.match(/(19|20)\d{2}/);
+      if (year) {
+        const years = new Date().getFullYear() - Number(year[0]);
+        accountAgeDays = Math.max(0, years) * 365;
+      }
+    } else if (lower.includes("star") || lower.includes("review")) {
+      const starMatch = text.match(/(\d+(\.\d+)?)\s*star/);
+      if (starMatch) ratingOverall = Number(starMatch[1]);
+      const reviewMatch = text.match(/(\d[\d,]*)\s*review/);
+      if (reviewMatch) ratingCount = Number(reviewMatch[1].replace(/,/g, ""));
+    } else if (lower.includes("responsive")) {
+      responseText = text;
+    }
+  }
+
+  return {
+    id,
+    displayName,
+    profileUrl,
+    profileImageUrl,
+    joinedDate,
+    accountAgeDays,
+    ratingOverall,
+    ratingCount,
+    responseText,
+    location: fallbackLocation,
+    activeListings: null,
+  };
+}
+
+/** Extract engagement counts from a detail page, or null if the block is absent. */
+export function extractDetailEngagement(
+  root: ParentNode,
+): { saves: number | null; comments: number | null; views: number | null } | null {
+  const block =
+    root.querySelector('[data-testid="marketplace-pdp-engagement"]') ??
+    root.querySelector('[data-testid*="engagement"]');
+  if (!block) return null;
+
+  let saves: number | null = null;
+  let comments: number | null = null;
+  let views: number | null = null;
+  for (const span of Array.from(block.querySelectorAll("span"))) {
+    const text = span.textContent?.trim() ?? "";
+    const lower = text.toLowerCase();
+    if (lower.includes("save")) saves = firstNumber(text);
+    else if (lower.includes("comment")) comments = firstNumber(text);
+    else if (lower.includes("view")) views = firstNumber(text);
+  }
+  if (saves === null && comments === null && views === null) return null;
+  return { saves, comments, views };
+}
+
+/**
+ * Compute a trust score for a parsed seller and return the persisted
+ * (flat) {@link SellerRecord}. Pure -- unit-tested.
+ */
+export function buildSellerRecord(parsed: ParsedSellerProfile): SellerRecord {
+  // calculateTrustScore stringifies `responseRate` for phrase matching ("very
+  // responsive", etc.), so we feed the response text through that field even
+  // though the domain type nominally types it as a number.
+  const domain: Partial<DomainSellerProfile> = {
+    accountAgeDays: parsed.accountAgeDays,
+    rating: {
+      overall: parsed.ratingOverall,
+      totalReviews: parsed.ratingCount,
+      positiveCount: null,
+      negativeCount: null,
+    },
+    profileImageUrl: parsed.profileImageUrl,
+    location: parsed.location,
+    activeListings: parsed.activeListings,
+    responseRate: parsed.responseText as unknown as number | null,
+  };
+  const trust = calculateTrustScore(domain);
+
+  return {
+    id: parsed.id,
+    name: parsed.displayName,
+    profileUrl: parsed.profileUrl,
+    accountAge: parsed.joinedDate,
+    accountAgeMonths: parsed.accountAgeDays != null ? Math.floor(parsed.accountAgeDays / 30) : null,
+    rating: parsed.ratingOverall,
+    ratingCount: parsed.ratingCount,
+    responseRate: parsed.responseText,
+    responseTime: null,
+    hasProfilePhoto: parsed.profileImageUrl != null,
+    hasCoverPhoto: false,
+    hasLocation: parsed.location != null,
+    hasBio: false,
+    activeListingCount: parsed.activeListings,
+    trustScore: trust.score,
+    trustScoreBreakdown: { ...trust.breakdown },
+    lastUpdated: new Date().toISOString(),
+  };
+}

--- a/src/content/detail-page-parser.ts
+++ b/src/content/detail-page-parser.ts
@@ -132,9 +132,6 @@ export function extractDetailEngagement(
  * (flat) {@link SellerRecord}. Pure -- unit-tested.
  */
 export function buildSellerRecord(parsed: ParsedSellerProfile): SellerRecord {
-  // calculateTrustScore stringifies `responseRate` for phrase matching ("very
-  // responsive", etc.), so we feed the response text through that field even
-  // though the domain type nominally types it as a number.
   const domain: Partial<DomainSellerProfile> = {
     accountAgeDays: parsed.accountAgeDays,
     rating: {
@@ -146,7 +143,7 @@ export function buildSellerRecord(parsed: ParsedSellerProfile): SellerRecord {
     profileImageUrl: parsed.profileImageUrl,
     location: parsed.location,
     activeListings: parsed.activeListings,
-    responseRate: parsed.responseText as unknown as number | null,
+    responseDescription: parsed.responseText,
   };
   const trust = calculateTrustScore(domain);
 

--- a/src/content/dom-injector.ts
+++ b/src/content/dom-injector.ts
@@ -362,6 +362,41 @@ export class DomInjector {
   }
 
   /**
+   * Inject (or update) a small "Compare" toggle button on a listing card.
+   * Idempotent: re-injecting updates the selected state rather than duplicating.
+   * Click handling is delegated centrally in the content script.
+   *
+   * @param listingElement - The listing card DOM element.
+   * @param listingId - The listing's id (set as a data attribute for delegation).
+   * @param selected - Whether this listing is currently in the comparison set.
+   */
+  injectCompareButton(listingElement: Element, listingId: string, selected: boolean): void {
+    try {
+      let btn = listingElement.querySelector<HTMLButtonElement>(".mps-card-compare-btn");
+      if (!btn) {
+        btn = document.createElement("button");
+        btn.className = "mps-card-compare-btn";
+        btn.type = "button";
+        btn.setAttribute("data-mps-part", "compare-button");
+        if (
+          listingElement instanceof HTMLElement &&
+          getComputedStyle(listingElement).position === "static"
+        ) {
+          listingElement.style.position = "relative";
+        }
+        listingElement.appendChild(btn);
+      }
+      btn.setAttribute("data-mps-listing-id", listingId);
+      btn.setAttribute("data-mps-selected", String(selected));
+      btn.setAttribute("aria-pressed", String(selected));
+      btn.title = selected ? "Remove from comparison" : "Add to comparison";
+      btn.textContent = selected ? "✓ Compare" : "+ Compare";
+    } catch (err) {
+      console.warn("[MPS] Failed to inject compare button:", err);
+    }
+  }
+
+  /**
    * Inject the preview panel used for quick-view of listing details.
    *
    * The panel slides in from the right when a user hovers or clicks a

--- a/src/content/dom-injector.ts
+++ b/src/content/dom-injector.ts
@@ -21,7 +21,7 @@
 /** Badge descriptor passed to {@link DomInjector.injectBadge}. */
 export interface BadgeDescriptor {
   /** Badge type, used for CSS class selection. */
-  readonly type: "trust" | "price" | "heat" | "image";
+  readonly type: "trust" | "price" | "heat" | "image" | "forecast";
   /** Severity / rating level within the type. */
   readonly level: string;
   /** Short text displayed inside the badge. */

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -168,6 +168,16 @@ async function bootstrap(): Promise<void> {
     await persistence.init();
     cleanupFns.push(() => persistence.close());
 
+    // Enforce data-retention settings so IndexedDB stays bounded.
+    storageGet<{ historyRetentionDays?: number; priceDataRetentionDays?: number }>(
+      "mps:settings",
+      {},
+    )
+      .then((s) =>
+        persistence.cleanup(s.historyRetentionDays ?? 30, s.priceDataRetentionDays ?? 90),
+      )
+      .catch(() => {});
+
     // 4. Wire the event flow
     //    Observer detects new DOM nodes -> Parser extracts Listing data ->
     //    EventBus broadcasts -> Filters/Sorters run -> DomManipulator updates DOM

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -26,7 +26,7 @@
 
 import "./styles.css";
 
-import { storageGet, onStorageChanged } from "@/platform/storage";
+import { storageGet, storageSet, onStorageChanged } from "@/platform/storage";
 import { browser } from "@/platform/browser";
 import { detectFacebookTheme, observeThemeChanges } from "@/design-system/theme/theme-detector";
 import { injectCSSVariables } from "@/design-system/theme/css-variables";
@@ -57,6 +57,8 @@ import { DetailPageEnhancer } from "@/content/detail-page-enhancer";
 import { ContentPersistence } from "@/content/persistence";
 import { analyzeListings } from "@/content/analysis-runner";
 import { buildBadges } from "@/content/badge-builder";
+import { createSidebarController, mountSidebar } from "@/content/sidebar-mount";
+import type { AnalyzedListing } from "@/core/models/analyzed-listing";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -99,6 +101,9 @@ let activeSortId: string | null = null;
 
 /** Current sort direction. */
 let activeSortDirection: "asc" | "desc" = "asc";
+
+/** Number of listings visible after the most recent filter pass. */
+let lastVisibleCount = 0;
 
 /** Cleanup functions for teardown. */
 const cleanupFns: Array<() => void> = [];
@@ -267,6 +272,29 @@ async function bootstrap(): Promise<void> {
     // 5. Inject UI elements FIRST (before loading settings, so sidebar exists
     //    when loadSettings emits SIDEBAR_TOGGLED to restore open state)
     injector.injectSidebar();
+
+    // 5b. Mount the React sidebar into the injected host, replacing the
+    //     placeholder vanilla controls, and bridge it to the live pipeline.
+    const sidebarController = createSidebarController({
+      getListings: () => Array.from(knownListings.values()) as AnalyzedListing[],
+      getVisibleCount: () => lastVisibleCount,
+      setActiveFilters: (configs) => {
+        activeFilters = configs;
+        storageSet(STORAGE_KEY_FILTERS, Object.fromEntries(configs)).catch(() => {});
+        applyFiltersAndSort(eventBus, filterEngine, sortEngine, manipulator, injector);
+      },
+      getSort: () => ({ id: activeSortId, direction: activeSortDirection }),
+      setSort: (id, direction) => {
+        activeSortId = id;
+        activeSortDirection = direction;
+        storageSet(STORAGE_KEY_SORT, id ? { id, direction } : null).catch(() => {});
+        applyFiltersAndSort(eventBus, filterEngine, sortEngine, manipulator, injector);
+      },
+      persistence,
+      subscribe: (event, handler) => eventBus.on(event, handler),
+    });
+    const sidebarMount = mountSidebar(sidebarController);
+    if (sidebarMount) cleanupFns.push(() => sidebarMount.unmount());
 
     // 6. Load persisted settings (may emit SIDEBAR_TOGGLED to reopen sidebar)
     await loadSettings(eventBus);
@@ -475,6 +503,7 @@ function applyFiltersAndSort(
 
     manipulator.showAllListings();
     manipulator.hideListings(hiddenIds);
+    lastVisibleCount = filterResult.listings.length;
 
     // Update stats to reflect filtered results
     const hasActiveFilters = activeFilters.size > 0;

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -59,6 +59,8 @@ import { analyzeListings } from "@/content/analysis-runner";
 import { buildBadges } from "@/content/badge-builder";
 import { createSidebarController, mountSidebar } from "@/content/sidebar-mount";
 import type { AnalyzedListing } from "@/core/models/analyzed-listing";
+import { compareListings } from "@/core/analysis/comparison-engine";
+import type { ComparisonResult } from "@/core/analysis/comparison-engine";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -86,6 +88,37 @@ function cssEscapeId(id: string): string {
   return id.replace(/["\\\]]/g, "\\$&");
 }
 
+/** Recompute the comparison result from the current selection (needs >= 2). */
+function recomputeComparison(): void {
+  const selected = Array.from(comparisonSelection)
+    .map((id) => knownListings.get(id) as AnalyzedListing | undefined)
+    .filter((l): l is AnalyzedListing => l !== undefined);
+  comparisonResult = selected.length >= 2 ? compareListings(selected) : null;
+}
+
+/** Map of selected listing id -> title, for comparison export/labels. */
+function comparisonTitles(): Record<string, string> {
+  const titles: Record<string, string> = {};
+  for (const id of comparisonSelection) {
+    const listing = knownListings.get(id);
+    if (listing) titles[id] = listing.title;
+  }
+  return titles;
+}
+
+/** Sync every injected compare button's visual state to the selection. */
+function refreshCompareButtons(): void {
+  document.querySelectorAll<HTMLButtonElement>(".mps-card-compare-btn").forEach((btn) => {
+    const id = btn.getAttribute("data-mps-listing-id");
+    if (!id) return;
+    const selected = comparisonSelection.has(id);
+    btn.setAttribute("data-mps-selected", String(selected));
+    btn.setAttribute("aria-pressed", String(selected));
+    btn.title = selected ? "Remove from comparison" : "Add to comparison";
+    btn.textContent = selected ? "✓ Compare" : "+ Compare";
+  });
+}
+
 // ---------------------------------------------------------------------------
 // State
 // ---------------------------------------------------------------------------
@@ -104,6 +137,15 @@ let activeSortDirection: "asc" | "desc" = "asc";
 
 /** Number of listings visible after the most recent filter pass. */
 let lastVisibleCount = 0;
+
+/** Maximum listings that can be compared side by side. */
+const MAX_COMPARISON = 4;
+
+/** Listing ids currently selected for comparison (insertion order). */
+const comparisonSelection = new Set<string>();
+
+/** The most recent comparison result, or null when fewer than 2 are selected. */
+let comparisonResult: ComparisonResult | null = null;
 
 /** Cleanup functions for teardown. */
 const cleanupFns: Array<() => void> = [];
@@ -233,7 +275,10 @@ async function bootstrap(): Promise<void> {
               const card = document.querySelector(
                 `[data-mps-listing-id="${cssEscapeId(a.id)}"]`,
               );
-              if (card) injector.injectBadge(card, buildBadges(a));
+              if (card) {
+                injector.injectBadge(card, buildBadges(a));
+                injector.injectCompareButton(card, a.id, comparisonSelection.has(a.id));
+              }
             } catch (err) {
               console.warn(`${LOG_PREFIX} Badge injection failed for ${a.id}:`, err);
             }
@@ -279,6 +324,43 @@ async function bootstrap(): Promise<void> {
       }
     });
 
+    // Comparison selection: card buttons emit COMPARISON_ADDED/REMOVED; these
+    // handlers (registered before the React provider mounts, so they run first)
+    // maintain the selection set and recompute the result the panel reads.
+    eventBus.on<{ listingId: string }>(MPS_EVENTS.COMPARISON_ADDED, ({ listingId }) => {
+      if (!comparisonSelection.has(listingId) && comparisonSelection.size >= MAX_COMPARISON) {
+        console.warn(`${LOG_PREFIX} Comparison limit (${MAX_COMPARISON}) reached`);
+        return;
+      }
+      comparisonSelection.add(listingId);
+      recomputeComparison();
+      refreshCompareButtons();
+    });
+    eventBus.on<{ listingId: string }>(MPS_EVENTS.COMPARISON_REMOVED, ({ listingId }) => {
+      comparisonSelection.delete(listingId);
+      recomputeComparison();
+      refreshCompareButtons();
+    });
+
+    // Delegated click handling for per-card compare buttons.
+    const onCompareClick = (e: MouseEvent): void => {
+      const target = e.target as Element | null;
+      const btn = target?.closest?.(".mps-card-compare-btn");
+      if (!btn) return;
+      e.preventDefault();
+      e.stopPropagation();
+      const id = btn.getAttribute("data-mps-listing-id");
+      if (!id) return;
+      eventBus.emit(
+        comparisonSelection.has(id)
+          ? MPS_EVENTS.COMPARISON_REMOVED
+          : MPS_EVENTS.COMPARISON_ADDED,
+        { listingId: id },
+      );
+    };
+    document.addEventListener("click", onCompareClick, true);
+    cleanupFns.push(() => document.removeEventListener("click", onCompareClick, true));
+
     // 5. Inject UI elements FIRST (before loading settings, so sidebar exists
     //    when loadSettings emits SIDEBAR_TOGGLED to restore open state)
     injector.injectSidebar();
@@ -301,6 +383,13 @@ async function bootstrap(): Promise<void> {
         applyFiltersAndSort(eventBus, filterEngine, sortEngine, manipulator, injector);
       },
       persistence,
+      getComparison: () => comparisonResult,
+      getComparisonTitles: () => comparisonTitles(),
+      clearComparison: () => {
+        comparisonSelection.clear();
+        recomputeComparison();
+        refreshCompareButtons();
+      },
       subscribe: (event, handler) => eventBus.on(event, handler),
     });
     const sidebarMount = mountSidebar(sidebarController);

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -40,6 +40,9 @@ import { PriceFilter } from "@/core/filters/price-filter";
 import { ConditionFilter } from "@/core/filters/condition-filter";
 import { DistanceFilter } from "@/core/filters/distance-filter";
 import { DateFilter } from "@/core/filters/date-filter";
+import { SellerTrustFilter } from "@/core/filters/seller-trust-filter";
+import { PriceRatingFilter } from "@/core/filters/price-rating-filter";
+import { ImageFlagFilter } from "@/core/filters/image-flag-filter";
 import { sortRegistry } from "@/core/sorters/sort-registry";
 import { ALL_SORTERS } from "@/core/sorters/sorters";
 import { SortEngine } from "@/core/sorters/sort-engine";
@@ -51,6 +54,8 @@ import { DomInjector } from "@/content/dom-injector";
 import { DomManipulator } from "@/content/dom-manipulator";
 import { runSelectorHealthCheck } from "@/content/selector-health-checker";
 import { DetailPageEnhancer } from "@/content/detail-page-enhancer";
+import { ContentPersistence } from "@/content/persistence";
+import { analyzeListings } from "@/content/analysis-runner";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -119,6 +124,9 @@ async function bootstrap(): Promise<void> {
     filterRegistry.register(new ConditionFilter() as unknown as IFilter);
     filterRegistry.register(new DistanceFilter() as unknown as IFilter);
     filterRegistry.register(new DateFilter() as unknown as IFilter);
+    filterRegistry.register(new SellerTrustFilter() as unknown as IFilter);
+    filterRegistry.register(new PriceRatingFilter() as unknown as IFilter);
+    filterRegistry.register(new ImageFlagFilter() as unknown as IFilter);
     console.log(`${LOG_PREFIX} Registered ${filterRegistry.size} filters`);
 
     // Register all sorters
@@ -137,6 +145,12 @@ async function bootstrap(): Promise<void> {
     const injector = new DomInjector();
     const manipulator = new DomManipulator();
     const detailEnhancer = new DetailPageEnhancer();
+
+    // Persistence layer (IndexedDB). Best-effort: if it fails to open, the
+    // pipeline still runs, just without comparables/history.
+    const persistence = new ContentPersistence();
+    await persistence.init();
+    cleanupFns.push(() => persistence.close());
 
     // 4. Wire the event flow
     //    Observer detects new DOM nodes -> Parser extracts Listing data ->
@@ -177,10 +191,29 @@ async function bootstrap(): Promise<void> {
       }
     });
 
-    // When listings are parsed, apply filters and sorts
+    // When listings are parsed: persist them, run analysis (price rating, heat,
+    // forecast), fold the enriched listings back into `knownListings`, then
+    // apply filters/sorts. Newly parsed listings are visible by default, so
+    // there is no blank period while the async IndexedDB work completes.
     eventBus.on<{ listings: Listing[]; total: number }>(
       MPS_EVENTS.LISTINGS_PARSED,
-      () => {
+      async ({ listings }) => {
+        try {
+          await persistence.saveListings(listings);
+          const analyzed = await analyzeListings(listings, persistence);
+          for (const a of analyzed) {
+            knownListings.set(a.id, a);
+          }
+          // Record engagement snapshots *after* analysis so heat velocity
+          // compares against the previous observation, not the current one.
+          await persistence.saveEngagement(listings);
+          eventBus.emit(MPS_EVENTS.ANALYSIS_COMPLETE, {
+            count: analyzed.length,
+            total: knownListings.size,
+          });
+        } catch (err) {
+          console.warn(`${LOG_PREFIX} Analysis/persistence error:`, err);
+        }
         applyFiltersAndSort(eventBus, filterEngine, sortEngine, manipulator, injector);
       },
     );

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -61,6 +61,11 @@ import { createSidebarController, mountSidebar } from "@/content/sidebar-mount";
 import type { AnalyzedListing } from "@/core/models/analyzed-listing";
 import { compareListings } from "@/core/analysis/comparison-engine";
 import type { ComparisonResult } from "@/core/analysis/comparison-engine";
+import {
+  extractSellerProfile,
+  extractDetailEngagement,
+  buildSellerRecord,
+} from "@/content/detail-page-parser";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -202,13 +207,26 @@ async function bootstrap(): Promise<void> {
     const parser = new ListingParser();
     const injector = new DomInjector();
     const manipulator = new DomManipulator();
-    const detailEnhancer = new DetailPageEnhancer();
 
     // Persistence layer (IndexedDB). Best-effort: if it fails to open, the
     // pipeline still runs, just without comparables/history.
     const persistence = new ContentPersistence();
     await persistence.init();
     cleanupFns.push(() => persistence.close());
+
+    // Detail-page enhancer: when a listing detail page loads, parse the seller
+    // profile + engagement (only available there), score and persist them so
+    // grid listings from the same seller pick up trust/heat.
+    const detailEnhancer = new DetailPageEnhancer((listingId) => {
+      try {
+        const parsed = extractSellerProfile(document);
+        if (parsed) persistence.saveSeller(buildSellerRecord(parsed)).catch(() => {});
+        const engagement = extractDetailEngagement(document);
+        if (engagement) persistence.saveDetailEngagement(listingId, engagement).catch(() => {});
+      } catch (err) {
+        console.warn(`${LOG_PREFIX} Detail-page parse failed:`, err);
+      }
+    });
 
     // Enforce data-retention settings so IndexedDB stays bounded.
     storageGet<{ historyRetentionDays?: number; priceDataRetentionDays?: number }>(

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -66,6 +66,7 @@ import {
   extractDetailEngagement,
   buildSellerRecord,
 } from "@/content/detail-page-parser";
+import type { ImageAnalysisResult } from "@/background/image-analysis";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -277,6 +278,62 @@ async function bootstrap(): Promise<void> {
       }
     });
 
+    // Optional image analysis: when enabled in settings, ask the background
+    // worker (which can fetch+decode cross-origin fbcdn images without canvas
+    // tainting) to score each listing's first image, then persist + badge it.
+    const requestedImageUrls = new Set<string>();
+    const maybeScanImages = async (listings: AnalyzedListing[]): Promise<void> => {
+      let settings: { autoScanImages?: boolean };
+      try {
+        settings = await storageGet<{ autoScanImages?: boolean }>("mps:settings", {});
+      } catch {
+        return;
+      }
+      if (!settings.autoScanImages) return;
+
+      let changed = false;
+      for (const listing of listings) {
+        const url = listing.imageUrls[0];
+        if (!url || requestedImageUrls.has(url)) continue;
+        requestedImageUrls.add(url);
+        try {
+          const result = (await browser.runtime.sendMessage({
+            action: "analyze-image",
+            payload: { url },
+          })) as ImageAnalysisResult | null;
+          if (!result) continue;
+
+          const flags = [...result.flags];
+          const dupes = (await persistence.findImageDuplicates(result.hash)).filter(
+            (d) => d.listingId !== listing.id,
+          );
+          if (dupes.length > 0 && !flags.includes("duplicate")) flags.push("duplicate");
+
+          await persistence.saveImageHash({
+            hash: result.hash,
+            listingId: listing.id,
+            imageUrl: url,
+            aiScore: result.aiScore / 100,
+            originalityScore: null,
+            flags,
+            analyzedAt: new Date().toISOString(),
+          });
+
+          const current = (knownListings.get(listing.id) as AnalyzedListing | undefined) ?? listing;
+          const updated: AnalyzedListing = { ...current, aiImageScore: result.aiScore, imageFlags: flags };
+          knownListings.set(listing.id, updated);
+          const card = document.querySelector(`[data-mps-listing-id="${cssEscapeId(listing.id)}"]`);
+          if (card) injector.injectBadge(card, buildBadges(updated));
+          changed = true;
+        } catch {
+          // best effort
+        }
+      }
+      if (changed) {
+        eventBus.emit(MPS_EVENTS.ANALYSIS_COMPLETE, { count: 0, total: knownListings.size });
+      }
+    };
+
     // When listings are parsed: persist them, run analysis (price rating, heat,
     // forecast), fold the enriched listings back into `knownListings`, then
     // apply filters/sorts. Newly parsed listings are visible by default, so
@@ -308,6 +365,8 @@ async function bootstrap(): Promise<void> {
             count: analyzed.length,
             total: knownListings.size,
           });
+          // Fire-and-forget image analysis (no-op unless enabled in settings).
+          void maybeScanImages(analyzed);
         } catch (err) {
           console.warn(`${LOG_PREFIX} Analysis/persistence error:`, err);
         }

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -56,6 +56,7 @@ import { runSelectorHealthCheck } from "@/content/selector-health-checker";
 import { DetailPageEnhancer } from "@/content/detail-page-enhancer";
 import { ContentPersistence } from "@/content/persistence";
 import { analyzeListings } from "@/content/analysis-runner";
+import { buildBadges } from "@/content/badge-builder";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -72,6 +73,16 @@ const STORAGE_KEY_SIDEBAR = "mps:sidebarOpen";
 
 /** Console log prefix. */
 const LOG_PREFIX = "[MPS]";
+
+/**
+ * Escape a listing id for safe use inside a CSS attribute selector.
+ * Uses the native `CSS.escape` when available, with a conservative fallback.
+ */
+function cssEscapeId(id: string): string {
+  const cssApi = (globalThis as { CSS?: { escape?: (s: string) => string } }).CSS;
+  if (cssApi?.escape) return cssApi.escape(id);
+  return id.replace(/["\\\]]/g, "\\$&");
+}
 
 // ---------------------------------------------------------------------------
 // State
@@ -203,6 +214,14 @@ async function bootstrap(): Promise<void> {
           const analyzed = await analyzeListings(listings, persistence);
           for (const a of analyzed) {
             knownListings.set(a.id, a);
+            try {
+              const card = document.querySelector(
+                `[data-mps-listing-id="${cssEscapeId(a.id)}"]`,
+              );
+              if (card) injector.injectBadge(card, buildBadges(a));
+            } catch (err) {
+              console.warn(`${LOG_PREFIX} Badge injection failed for ${a.id}:`, err);
+            }
           }
           // Record engagement snapshots *after* analysis so heat velocity
           // compares against the previous observation, not the current one.

--- a/src/content/persistence.test.ts
+++ b/src/content/persistence.test.ts
@@ -4,7 +4,10 @@ import {
   listingToRecord,
   listingToPricePoint,
   listingToEngagementSnapshot,
+  toRecentMirror,
+  mergeRecent,
 } from "@/content/persistence";
+import type { RecentListingMirror } from "@/content/persistence";
 
 const BASE = {
   id: "42",
@@ -71,5 +74,47 @@ describe("listingToEngagementSnapshot", () => {
   it("returns null when no engagement metrics are present", () => {
     const listing = createListing({ ...BASE });
     expect(listingToEngagementSnapshot(listing)).toBeNull();
+  });
+});
+
+describe("toRecentMirror / mergeRecent", () => {
+  it("projects a listing into its compact mirror", () => {
+    const listing = createListing({ ...BASE, price: 120, firstObserved: 1000 });
+    expect(toRecentMirror(listing)).toEqual({
+      id: "42",
+      title: "Mid Century Dresser",
+      price: 120,
+      url: BASE.listingUrl,
+      firstObserved: 1000,
+    });
+  });
+
+  it("de-duplicates by id, preserving the original firstObserved", () => {
+    const existing: RecentListingMirror[] = [
+      { id: "a", title: "A", price: 1, url: "u", firstObserved: 100 },
+    ];
+    const incoming: RecentListingMirror[] = [
+      { id: "a", title: "A", price: 1, url: "u", firstObserved: 999 },
+      { id: "b", title: "B", price: 2, url: "u", firstObserved: 200 },
+    ];
+    const merged = mergeRecent(existing, incoming, 10);
+    expect(merged.map((r) => r.id)).toEqual(["a", "b"]);
+    expect(merged.find((r) => r.id === "a")?.firstObserved).toBe(100);
+  });
+
+  it("caps to the most recent entries", () => {
+    const existing: RecentListingMirror[] = Array.from({ length: 5 }, (_, i) => ({
+      id: `e${i}`,
+      title: "x",
+      price: null,
+      url: "u",
+      firstObserved: i,
+    }));
+    const incoming: RecentListingMirror[] = [
+      { id: "new", title: "new", price: null, url: "u", firstObserved: 99 },
+    ];
+    const merged = mergeRecent(existing, incoming, 3);
+    expect(merged).toHaveLength(3);
+    expect(merged[merged.length - 1].id).toBe("new");
   });
 });

--- a/src/content/persistence.test.ts
+++ b/src/content/persistence.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import { createListing } from "@/core/models/listing";
+import {
+  listingToRecord,
+  listingToPricePoint,
+  listingToEngagementSnapshot,
+} from "@/content/persistence";
+
+const BASE = {
+  id: "42",
+  title: "Mid Century Dresser",
+  listingUrl: "https://facebook.com/marketplace/item/42",
+};
+
+describe("listingToRecord", () => {
+  it("maps core fields and converts timestamps to ISO strings", () => {
+    const ts = Date.parse("2024-01-15T12:00:00.000Z");
+    const listing = createListing({
+      ...BASE,
+      price: 120,
+      category: "Furniture",
+      condition: "good",
+      firstObserved: ts,
+      lastObserved: ts,
+    });
+
+    const record = listingToRecord(listing);
+
+    expect(record.id).toBe("42");
+    expect(record.price).toBe(120);
+    expect(record.condition).toBe("good");
+    expect(record.firstObserved).toBe("2024-01-15T12:00:00.000Z");
+    expect(record.lastObserved).toBe("2024-01-15T12:00:00.000Z");
+    expect(record.disappeared).toBe(false);
+  });
+
+  it("stores an unknown condition as null", () => {
+    const listing = createListing({ ...BASE });
+    expect(listingToRecord(listing).condition).toBeNull();
+  });
+});
+
+describe("listingToPricePoint", () => {
+  it("returns a data point for a priced listing", () => {
+    const listing = createListing({ ...BASE, price: 120, category: "Furniture" });
+    const point = listingToPricePoint(listing);
+    expect(point).not.toBeNull();
+    expect(point?.price).toBe(120);
+    expect(point?.listingId).toBe("42");
+    expect(point?.id).toContain("42-");
+  });
+
+  it("returns null for free / unpriced listings", () => {
+    expect(listingToPricePoint(createListing({ ...BASE, price: null }))).toBeNull();
+    expect(listingToPricePoint(createListing({ ...BASE, price: 0 }))).toBeNull();
+  });
+});
+
+describe("listingToEngagementSnapshot", () => {
+  it("returns a snapshot when any engagement metric is present", () => {
+    const listing = createListing({
+      ...BASE,
+      engagement: { saves: 5, comments: null, views: null },
+    });
+    const snap = listingToEngagementSnapshot(listing);
+    expect(snap).not.toBeNull();
+    expect(snap?.saves).toBe(5);
+    expect(snap?.searchPosition).toBeNull();
+  });
+
+  it("returns null when no engagement metrics are present", () => {
+    const listing = createListing({ ...BASE });
+    expect(listingToEngagementSnapshot(listing)).toBeNull();
+  });
+});

--- a/src/content/persistence.ts
+++ b/src/content/persistence.ts
@@ -36,6 +36,7 @@ import type {
   PriceDataPoint,
   EngagementSnapshot,
   SellerProfile,
+  ImageHash,
 } from "@/data/db-schema";
 
 const LOG_PREFIX = "[MPS:persistence]";
@@ -382,6 +383,26 @@ export class ContentPersistence implements AnalysisDataSource {
       });
     } catch (err) {
       console.warn(`${LOG_PREFIX} Failed to persist detail engagement for ${listingId}:`, err);
+    }
+  }
+
+  /** Persist a computed image hash + analysis result. */
+  async saveImageHash(record: ImageHash): Promise<void> {
+    if (!this.ready || !this.imageHashes) return;
+    try {
+      await this.imageHashes.save(record);
+    } catch (err) {
+      console.warn(`${LOG_PREFIX} Failed to persist image hash for ${record.listingId}:`, err);
+    }
+  }
+
+  /** Return stored hashes within the duplicate threshold of the given hash. */
+  async findImageDuplicates(hash: string): Promise<ImageHash[]> {
+    if (!this.ready || !this.imageHashes) return [];
+    try {
+      return await this.imageHashes.findDuplicates(hash);
+    } catch {
+      return [];
     }
   }
 

--- a/src/content/persistence.ts
+++ b/src/content/persistence.ts
@@ -1,0 +1,254 @@
+/**
+ * @module content/persistence
+ *
+ * Bridges parsed {@link Listing} objects into the IndexedDB persistence layer.
+ *
+ * Until this module existed, the entire `data/` layer (repositories, schema,
+ * migrations) was dead code -- nothing in the running extension ever wrote to
+ * or read from IndexedDB. This service is instantiated by the content-script
+ * composition root (`content/index.ts`) and called whenever new listings are
+ * parsed, so that:
+ *
+ *  - listings accumulate across page sessions (`listings` store),
+ *  - a corpus of comparable prices is built up for the price rater
+ *    (`priceData` store, which needs 5+ comparables to produce a rating),
+ *  - engagement snapshots accumulate so the heat tracker can compute velocity
+ *    from a *previous* snapshot (`engagement` store).
+ *
+ * The record-mapping helpers ({@link listingToRecord},
+ * {@link listingToPricePoint}, {@link listingToEngagementSnapshot}) are pure
+ * and exported so they can be unit-tested without a live IndexedDB.
+ *
+ * All IndexedDB access is wrapped in try/catch: persistence is best-effort and
+ * must never break the filter/sort pipeline if the database is unavailable
+ * (e.g. private browsing, storage disabled).
+ */
+
+import { IndexedDBAdapter } from "@/data/db";
+import { ListingRepository } from "@/data/repositories/listing.repository";
+import { PriceDataRepository } from "@/data/repositories/price-data.repository";
+import { EngagementRepository } from "@/data/repositories/engagement.repository";
+import { SellerRepository } from "@/data/repositories/seller.repository";
+import { ImageHashRepository } from "@/data/repositories/image-hash.repository";
+import type { Listing } from "@/core/models/listing";
+import type {
+  ListingRecord,
+  PriceDataPoint,
+  EngagementSnapshot,
+} from "@/data/db-schema";
+
+const LOG_PREFIX = "[MPS:persistence]";
+
+/** Convert a Unix-epoch millisecond timestamp to an ISO 8601 string. */
+function msToIso(ms: number): string {
+  return new Date(ms).toISOString();
+}
+
+/**
+ * Map an in-memory {@link Listing} to its persisted {@link ListingRecord}.
+ *
+ * Pure function (no I/O) -- exported for testing.
+ */
+export function listingToRecord(listing: Listing): ListingRecord {
+  return {
+    id: listing.id,
+    title: listing.title,
+    normalizedTitle: listing.normalizedTitle,
+    titleTokens: [...listing.titleTokens],
+    category: listing.category,
+    condition: listing.condition === "unknown" ? null : listing.condition,
+    price: listing.price,
+    currency: listing.currency,
+    location: listing.location,
+    distance: listing.distance,
+    sellerName: listing.sellerName,
+    sellerProfileUrl: listing.sellerProfileUrl,
+    listingUrl: listing.listingUrl,
+    imageUrls: [...listing.imageUrls],
+    datePosted: listing.datePosted,
+    firstObserved: msToIso(listing.firstObserved),
+    lastObserved: msToIso(listing.lastObserved),
+    disappeared: false,
+    disappearedAt: null,
+  };
+}
+
+/**
+ * Map a {@link Listing} to a {@link PriceDataPoint}, or `null` when the
+ * listing has no usable price (free/unparseable listings are not comparables).
+ *
+ * Pure function -- exported for testing.
+ */
+export function listingToPricePoint(listing: Listing): PriceDataPoint | null {
+  if (listing.price === null || listing.price <= 0) return null;
+  const observedAt = msToIso(listing.lastObserved);
+  return {
+    id: `${listing.id}-${observedAt}`,
+    listingId: listing.id,
+    category: listing.category,
+    normalizedTitle: listing.normalizedTitle,
+    condition: listing.condition === "unknown" ? null : listing.condition,
+    price: listing.price,
+    location: listing.location,
+    observedAt,
+  };
+}
+
+/**
+ * Map a {@link Listing} to an {@link EngagementSnapshot}, or `null` when the
+ * listing carries no engagement data worth snapshotting.
+ *
+ * Pure function -- exported for testing.
+ */
+export function listingToEngagementSnapshot(
+  listing: Listing,
+): EngagementSnapshot | null {
+  const { saves, comments, views } = listing.engagement;
+  if (saves === null && comments === null && views === null) return null;
+  const observedAt = msToIso(listing.lastObserved);
+  return {
+    id: `${listing.id}-${observedAt}`,
+    listingId: listing.id,
+    saves,
+    comments,
+    views,
+    searchPosition: null,
+    observedAt,
+  };
+}
+
+/**
+ * Read-only view of persisted data that the analysis runner depends on.
+ * Implemented by {@link ContentPersistence}; mocked in tests.
+ */
+export interface AnalysisDataSource {
+  /**
+   * Return prices of comparable listings (same normalized title, falling back
+   * to same category) for the price rater. Excludes the listing itself.
+   */
+  getComparablePrices(listing: Listing): Promise<number[]>;
+
+  /** Return the most recent engagement snapshot recorded *before* this call. */
+  getPreviousEngagement(listingId: string): Promise<EngagementSnapshot | null>;
+}
+
+/**
+ * IndexedDB-backed persistence service for the content script.
+ *
+ * Construct, call {@link init} once, then call {@link persist} with each batch
+ * of newly parsed listings. Also implements {@link AnalysisDataSource} so the
+ * analysis runner can read comparables/engagement back out.
+ */
+export class ContentPersistence implements AnalysisDataSource {
+  private adapter: IndexedDBAdapter | null = null;
+  private listings: ListingRepository | null = null;
+  private prices: PriceDataRepository | null = null;
+  private engagement: EngagementRepository | null = null;
+  private sellers: SellerRepository | null = null;
+  private imageHashes: ImageHashRepository | null = null;
+
+  /** Whether IndexedDB initialized successfully. */
+  get ready(): boolean {
+    return this.adapter !== null;
+  }
+
+  /** Expose the image-hash repository for the image-analysis pipeline. */
+  get imageHashRepository(): ImageHashRepository | null {
+    return this.imageHashes;
+  }
+
+  /**
+   * Open the database and construct repositories. Resolves (without throwing)
+   * even if IndexedDB is unavailable -- persistence simply becomes a no-op.
+   */
+  async init(): Promise<void> {
+    try {
+      const adapter = new IndexedDBAdapter();
+      await adapter.init();
+      const db = adapter.getDB();
+      this.adapter = adapter;
+      this.listings = new ListingRepository(db);
+      this.prices = new PriceDataRepository(db);
+      this.engagement = new EngagementRepository(db);
+      this.sellers = new SellerRepository(db);
+      this.imageHashes = new ImageHashRepository(db);
+    } catch (err) {
+      console.warn(`${LOG_PREFIX} IndexedDB unavailable; persistence disabled.`, err);
+      this.adapter = null;
+    }
+  }
+
+  /**
+   * Persist a batch of newly parsed listings: upsert each listing record and
+   * append a price data point when the listing has a usable price. Call this
+   * *before* running analysis so a batch's siblings are available as price
+   * comparables. Engagement snapshots are saved separately via
+   * {@link saveEngagement} so the analysis runner can read the *previous*
+   * snapshot first. Best-effort; never throws.
+   */
+  async saveListings(listings: Listing[]): Promise<void> {
+    if (!this.ready) return;
+    for (const listing of listings) {
+      try {
+        await this.listings?.save(listingToRecord(listing));
+        const pricePoint = listingToPricePoint(listing);
+        if (pricePoint) await this.prices?.save(pricePoint);
+      } catch (err) {
+        console.warn(`${LOG_PREFIX} Failed to persist listing ${listing.id}:`, err);
+      }
+    }
+  }
+
+  /**
+   * Persist engagement snapshots for a batch. Call this *after* the analysis
+   * runner has read previous snapshots (so heat velocity compares against the
+   * prior observation, not the one being written now). Best-effort.
+   */
+  async saveEngagement(listings: Listing[]): Promise<void> {
+    if (!this.ready) return;
+    for (const listing of listings) {
+      try {
+        const snapshot = listingToEngagementSnapshot(listing);
+        if (snapshot) await this.engagement?.save(snapshot);
+      } catch (err) {
+        console.warn(`${LOG_PREFIX} Failed to persist engagement for ${listing.id}:`, err);
+      }
+    }
+  }
+
+  /** @inheritdoc */
+  async getComparablePrices(listing: Listing): Promise<number[]> {
+    if (!this.ready || !this.prices) return [];
+    try {
+      let points = await this.prices.getByTitle(listing.normalizedTitle);
+      // Fall back to category when there aren't enough same-title comparables.
+      if (points.length < 5 && listing.category) {
+        points = await this.prices.getByCategory(listing.category);
+      }
+      return points
+        .filter((p) => p.listingId !== listing.id && p.price > 0)
+        .map((p) => p.price);
+    } catch (err) {
+      console.warn(`${LOG_PREFIX} Failed to read comparables for ${listing.id}:`, err);
+      return [];
+    }
+  }
+
+  /** @inheritdoc */
+  async getPreviousEngagement(
+    listingId: string,
+  ): Promise<EngagementSnapshot | null> {
+    if (!this.ready || !this.engagement) return null;
+    try {
+      return await this.engagement.getLatest(listingId);
+    } catch {
+      return null;
+    }
+  }
+
+  /** Close the database connection. */
+  close(): void {
+    this.adapter?.close();
+    this.adapter = null;
+  }
+}

--- a/src/content/persistence.ts
+++ b/src/content/persistence.ts
@@ -35,6 +35,7 @@ import type {
   ListingRecord,
   PriceDataPoint,
   EngagementSnapshot,
+  SellerProfile,
 } from "@/data/db-schema";
 
 const LOG_PREFIX = "[MPS:persistence]";
@@ -186,6 +187,9 @@ export interface AnalysisDataSource {
 
   /** Return the most recent engagement snapshot recorded *before* this call. */
   getPreviousEngagement(listingId: string): Promise<EngagementSnapshot | null>;
+
+  /** Return a seller's cached trust score (from a visited detail page), or null. */
+  getSellerTrustScore(sellerProfileUrl: string): Promise<number | null>;
 }
 
 /**
@@ -346,6 +350,49 @@ export class ContentPersistence implements AnalysisDataSource {
     } catch (err) {
       console.warn(`${LOG_PREFIX} Failed to read comparables for ${listing.id}:`, err);
       return [];
+    }
+  }
+
+  /** Persist a scored seller profile (parsed from a detail page). */
+  async saveSeller(record: SellerProfile): Promise<void> {
+    if (!this.ready || !this.sellers) return;
+    try {
+      await this.sellers.save(record);
+    } catch (err) {
+      console.warn(`${LOG_PREFIX} Failed to persist seller ${record.id}:`, err);
+    }
+  }
+
+  /** Persist an engagement snapshot for a single listing (detail-page data). */
+  async saveDetailEngagement(
+    listingId: string,
+    engagement: { saves: number | null; comments: number | null; views: number | null },
+  ): Promise<void> {
+    if (!this.ready || !this.engagement) return;
+    try {
+      const observedAt = new Date().toISOString();
+      await this.engagement.save({
+        id: `${listingId}-${observedAt}`,
+        listingId,
+        saves: engagement.saves,
+        comments: engagement.comments,
+        views: engagement.views,
+        searchPosition: null,
+        observedAt,
+      });
+    } catch (err) {
+      console.warn(`${LOG_PREFIX} Failed to persist detail engagement for ${listingId}:`, err);
+    }
+  }
+
+  /** @inheritdoc */
+  async getSellerTrustScore(sellerProfileUrl: string): Promise<number | null> {
+    if (!this.ready || !this.sellers) return null;
+    try {
+      const seller = await this.sellers.getByUrl(sellerProfileUrl);
+      return seller?.trustScore ?? null;
+    } catch {
+      return null;
     }
   }
 

--- a/src/content/persistence.ts
+++ b/src/content/persistence.ts
@@ -371,6 +371,26 @@ export class ContentPersistence implements AnalysisDataSource {
     }
   }
 
+  /**
+   * Delete persisted data older than the configured retention windows. Keeps
+   * IndexedDB bounded so a heavy browsing history doesn't grow without limit.
+   * Best-effort; never throws.
+   */
+  async cleanup(historyDays: number, priceDataDays: number): Promise<void> {
+    if (!this.ready) return;
+    const cutoff = (days: number): string =>
+      new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
+    try {
+      const historyCutoff = cutoff(historyDays);
+      await this.listings?.deleteOlderThan(historyCutoff);
+      await this.engagement?.deleteOlderThan(historyCutoff);
+      await this.imageHashes?.deleteOlderThan(historyCutoff);
+      await this.prices?.deleteOlderThan(cutoff(priceDataDays));
+    } catch (err) {
+      console.warn(`${LOG_PREFIX} Retention cleanup failed:`, err);
+    }
+  }
+
   /** Close the database connection. */
   close(): void {
     this.adapter?.close();

--- a/src/content/persistence.ts
+++ b/src/content/persistence.ts
@@ -349,6 +349,16 @@ export class ContentPersistence implements AnalysisDataSource {
     }
   }
 
+  /** Return the most recently observed listing records (for the history panel). */
+  async getRecentListings(limit: number): Promise<ListingRecord[]> {
+    if (!this.ready || !this.listings) return [];
+    try {
+      return await this.listings.getRecent(limit);
+    } catch {
+      return [];
+    }
+  }
+
   /** @inheritdoc */
   async getPreviousEngagement(
     listingId: string,

--- a/src/content/persistence.ts
+++ b/src/content/persistence.ts
@@ -39,6 +39,62 @@ import type {
 
 const LOG_PREFIX = "[MPS:persistence]";
 
+/** chrome.storage keys read by the background alert worker. */
+const RECENT_LISTINGS_KEY = "mps-recent-listings";
+const PRICE_HISTORY_KEY = "mps-price-history";
+
+/** Maximum number of recent listings mirrored for saved-search matching. */
+const RECENT_CAP = 300;
+
+/**
+ * Compact listing shape mirrored to `chrome.storage.local` so the background
+ * service worker can match saved searches against newly seen listings.
+ */
+export interface RecentListingMirror {
+  id: string;
+  title: string;
+  price: number | null;
+  url: string;
+  /** Unix-epoch milliseconds when first observed. */
+  firstObserved: number;
+}
+
+/** A detected price drop mirrored for the background worker's drop alerts. */
+export interface PriceHistoryMirror {
+  listingId: string;
+  title: string;
+  url: string;
+  previousPrice: number;
+  currentPrice: number;
+}
+
+/** Project a listing into its compact recent-listing mirror. Pure. */
+export function toRecentMirror(listing: Listing): RecentListingMirror {
+  return {
+    id: listing.id,
+    title: listing.title,
+    price: listing.price,
+    url: listing.listingUrl,
+    firstObserved: listing.firstObserved,
+  };
+}
+
+/**
+ * Merge incoming recent-listing mirrors into the existing list, de-duplicating
+ * by id (existing entries keep their original `firstObserved`) and capping to
+ * the most recent `cap` entries. Pure.
+ */
+export function mergeRecent(
+  existing: RecentListingMirror[],
+  incoming: RecentListingMirror[],
+  cap: number,
+): RecentListingMirror[] {
+  const byId = new Map<string, RecentListingMirror>();
+  for (const r of existing) byId.set(r.id, r);
+  for (const r of incoming) if (!byId.has(r.id)) byId.set(r.id, r);
+  return Array.from(byId.values()).slice(-cap);
+}
+
 /** Convert a Unix-epoch millisecond timestamp to an ISO 8601 string. */
 function msToIso(ms: number): string {
   return new Date(ms).toISOString();
@@ -188,14 +244,73 @@ export class ContentPersistence implements AnalysisDataSource {
    */
   async saveListings(listings: Listing[]): Promise<void> {
     if (!this.ready) return;
+    const drops: PriceHistoryMirror[] = [];
     for (const listing of listings) {
       try {
+        // Detect a price drop by comparing against the previously stored record
+        // *before* it is overwritten below.
+        const previous = await this.listings?.getById(listing.id);
+        if (
+          previous &&
+          previous.price !== null &&
+          listing.price !== null &&
+          listing.price < previous.price
+        ) {
+          drops.push({
+            listingId: listing.id,
+            title: listing.title,
+            url: listing.listingUrl,
+            previousPrice: previous.price,
+            currentPrice: listing.price,
+          });
+        }
+
         await this.listings?.save(listingToRecord(listing));
         const pricePoint = listingToPricePoint(listing);
         if (pricePoint) await this.prices?.save(pricePoint);
       } catch (err) {
         console.warn(`${LOG_PREFIX} Failed to persist listing ${listing.id}:`, err);
       }
+    }
+    await this.mirrorForAlerts(listings, drops);
+  }
+
+  /**
+   * Mirror the batch into `chrome.storage.local` so the background worker can
+   * raise saved-search and price-drop notifications (the worker has no access
+   * to the page DOM or IndexedDB). Best-effort; never throws.
+   */
+  private async mirrorForAlerts(
+    listings: Listing[],
+    drops: PriceHistoryMirror[],
+  ): Promise<void> {
+    try {
+      // Imported lazily so the pure mapping helpers in this module can be unit
+      // tested without loading the webextension polyfill (which throws outside
+      // an extension context).
+      const { browser } = await import("@/platform/browser");
+      const stored = await browser.storage.local.get([
+        RECENT_LISTINGS_KEY,
+        PRICE_HISTORY_KEY,
+      ]);
+      const data = stored as Record<string, unknown>;
+
+      const existingRecent = (data[RECENT_LISTINGS_KEY] ?? []) as RecentListingMirror[];
+      const recent = mergeRecent(
+        existingRecent,
+        listings.map(toRecentMirror),
+        RECENT_CAP,
+      );
+
+      const existingHistory = (data[PRICE_HISTORY_KEY] ?? []) as PriceHistoryMirror[];
+      const history = drops.length > 0 ? [...existingHistory, ...drops] : existingHistory;
+
+      await browser.storage.local.set({
+        [RECENT_LISTINGS_KEY]: recent,
+        [PRICE_HISTORY_KEY]: history,
+      });
+    } catch (err) {
+      console.warn(`${LOG_PREFIX} Failed to mirror alert storage:`, err);
     }
   }
 

--- a/src/content/sidebar-mount.tsx
+++ b/src/content/sidebar-mount.tsx
@@ -27,6 +27,7 @@ import {
   type HistoryEntry,
 } from "@/ui/sidebar/sidebar-context";
 import type { AnalyzedListing } from "@/core/models/analyzed-listing";
+import type { ComparisonResult } from "@/core/analysis/comparison-engine";
 import type { ContentPersistence } from "@/content/persistence";
 import { storageGet, storageSet } from "@/platform/storage";
 
@@ -161,6 +162,12 @@ export interface SidebarMountDeps {
   /** Set the active sort and re-run the pipeline. */
   setSort: (id: string | null, direction: "asc" | "desc") => void;
   persistence: ContentPersistence;
+  /** Current comparison result (null when fewer than 2 are selected). */
+  getComparison: () => ComparisonResult | null;
+  /** Map of selected listing id -> title. */
+  getComparisonTitles: () => Record<string, string>;
+  /** Clear the comparison selection. */
+  clearComparison: () => void;
   /** Subscribe to a pipeline event; returns an unsubscribe function. */
   subscribe: (event: string, handler: () => void) => () => void;
 }
@@ -264,11 +271,9 @@ export function createSidebarController(deps: SidebarMountDeps): SidebarControll
       return records.map(toHistoryEntry);
     },
 
-    // Per-card comparison selection is not wired yet; the panel shows its empty
-    // state until "add to compare" controls exist on cards.
-    getComparison: () => null,
-    getComparisonTitles: () => ({}),
-    clearComparison: () => {},
+    getComparison: () => deps.getComparison(),
+    getComparisonTitles: () => deps.getComparisonTitles(),
+    clearComparison: () => deps.clearComparison(),
 
     subscribe: (event, handler) => deps.subscribe(event, handler),
   };

--- a/src/content/sidebar-mount.tsx
+++ b/src/content/sidebar-mount.tsx
@@ -1,0 +1,305 @@
+/**
+ * @module content/sidebar-mount
+ *
+ * Mounts the React sidebar (previously orphaned in `ui/sidebar/*`) into the
+ * content script's injected sidebar host and bridges it to the running
+ * pipeline via a {@link SidebarController}.
+ *
+ * Responsibilities:
+ *  - translate the panel's {@link FilterState} into the filter engine's config
+ *    map (and back-fill saved searches / settings via chrome.storage);
+ *  - expose live analyzed listings and derived counts to the panels;
+ *  - render `<SidebarTabs>` inside `.mps-sidebar-content`, wrapped in the data
+ *    provider, replacing the placeholder vanilla controls.
+ */
+
+import React from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { SidebarTabs } from "@/ui/sidebar/Sidebar";
+import {
+  SidebarDataProvider,
+  DEFAULT_FILTERS,
+  DEFAULT_SETTINGS,
+  type SidebarController,
+  type FilterState,
+  type SavedSearchItem,
+  type SettingsState,
+  type HistoryEntry,
+} from "@/ui/sidebar/sidebar-context";
+import type { AnalyzedListing } from "@/core/models/analyzed-listing";
+import type { ContentPersistence } from "@/content/persistence";
+import { storageGet, storageSet } from "@/platform/storage";
+
+/** chrome.storage key shared with the background alert worker. */
+const SAVED_SEARCHES_KEY = "mps-saved-searches";
+/** chrome.storage key for persisted feature settings. */
+const SETTINGS_KEY = "mps:settings";
+
+/** Saved search as persisted: the UI shape plus fields the worker reads. */
+interface StoredSavedSearch extends SavedSearchItem {
+  filters?: FilterState;
+  sortId?: string | null;
+  sortDirection?: "asc" | "desc";
+  notifications?: { enabled: boolean; frequency: string };
+}
+
+/** Best->worst price rating order, used to map tier checkboxes to a floor. */
+const RATING_ORDER = [
+  "steal",
+  "great-deal",
+  "good-price",
+  "fair-price",
+  "above-market",
+  "high",
+  "overpriced",
+];
+
+const DATE_TO_HOURS: Record<string, number> = {
+  "1h": 1,
+  "24h": 24,
+  "7d": 168,
+  "30d": 720,
+};
+
+/**
+ * Translate the panel's {@link FilterState} into the filter engine's config
+ * map (keyed by filter id). Only meaningfully-configured filters are included
+ * so unset controls remain no-ops.
+ */
+export function filterStateToConfigs(
+  state: FilterState,
+): Map<string, Record<string, unknown>> {
+  const configs = new Map<string, Record<string, unknown>>();
+
+  if (state.keywords.trim()) {
+    configs.set("keyword-include", { keywords: state.keywords.trim(), fuzzyLevel: "off" });
+  }
+  if (state.excludeKeywords.trim()) {
+    configs.set("keyword-exclude", { keywords: state.excludeKeywords.trim(), fuzzyLevel: "off" });
+  }
+
+  const min = state.priceMin ? Number(state.priceMin) : null;
+  const max = state.priceMax ? Number(state.priceMax) : null;
+  if ((min !== null && !Number.isNaN(min)) || (max !== null && !Number.isNaN(max))) {
+    configs.set("price-range", {
+      min: min !== null && !Number.isNaN(min) ? min : null,
+      max: max !== null && !Number.isNaN(max) ? max : null,
+    });
+  }
+
+  const distance = state.maxDistance ? Number(state.maxDistance) : null;
+  if (distance !== null && !Number.isNaN(distance)) {
+    configs.set("distance-radius", { maxDistance: distance });
+  }
+
+  const conditions = Object.entries(state.conditions)
+    .filter(([, on]) => on)
+    .map(([k]) => k);
+  if (conditions.length > 0) {
+    configs.set("condition", { conditions });
+  }
+
+  if (state.datePosted !== "any" && DATE_TO_HOURS[state.datePosted] !== undefined) {
+    configs.set("date-posted", { maxAgeHours: DATE_TO_HOURS[state.datePosted] });
+  }
+
+  const minTrust = state.minTrustScore ? Number(state.minTrustScore) : 0;
+  if (minTrust > 0 && !Number.isNaN(minTrust)) {
+    configs.set("seller-trust", { minTrustScore: minTrust });
+  }
+
+  if (state.minImageQuality.trim()) {
+    configs.set("image-flags", {
+      hideAiGenerated: true,
+      hideStockPhotos: false,
+      onlyOriginal: false,
+    });
+  }
+
+  const checkedTiers = Object.entries(state.priceRatingTiers)
+    .filter(([, on]) => on)
+    .map(([k]) => k);
+  if (checkedTiers.length > 0) {
+    // Map the multi-select tiers to the worst (lowest-quality) checked tier as
+    // a minimum-rating floor: keeps everything at least that good.
+    const worst = checkedTiers.reduce((acc, t) =>
+      RATING_ORDER.indexOf(t) > RATING_ORDER.indexOf(acc) ? t : acc,
+    );
+    configs.set("price-rating", { minRating: worst, hideOverpriced: false });
+  }
+
+  return configs;
+}
+
+/** Map a persisted listing record to the history panel's view-model. */
+function toHistoryEntry(r: {
+  id: string;
+  title: string;
+  price: number | null;
+  imageUrls: string[];
+  firstObserved: string;
+  lastObserved: string;
+}): HistoryEntry {
+  return {
+    listingId: r.id,
+    title: r.title,
+    price: r.price,
+    imageUrl: r.imageUrls.length > 0 ? r.imageUrls[0] : null,
+    firstSeen: Date.parse(r.firstObserved) || 0,
+    lastSeen: Date.parse(r.lastObserved) || 0,
+    viewCount: 0,
+  };
+}
+
+/** Dependencies the controller needs from the content-script composition root. */
+export interface SidebarMountDeps {
+  getListings: () => AnalyzedListing[];
+  getVisibleCount: () => number;
+  /** Replace the active filter configs, persist, and re-run the pipeline. */
+  setActiveFilters: (configs: Map<string, Record<string, unknown>>) => void;
+  getSort: () => { id: string | null; direction: "asc" | "desc" };
+  /** Set the active sort and re-run the pipeline. */
+  setSort: (id: string | null, direction: "asc" | "desc") => void;
+  persistence: ContentPersistence;
+  /** Subscribe to a pipeline event; returns an unsubscribe function. */
+  subscribe: (event: string, handler: () => void) => () => void;
+}
+
+/** Build the {@link SidebarController} that bridges React panels to the pipeline. */
+export function createSidebarController(deps: SidebarMountDeps): SidebarController {
+  let currentFilterState: FilterState = DEFAULT_FILTERS;
+
+  const applyState = (state: FilterState): void => {
+    currentFilterState = state;
+    deps.setActiveFilters(filterStateToConfigs(state));
+  };
+
+  async function loadStored(): Promise<StoredSavedSearch[]> {
+    return storageGet<StoredSavedSearch[]>(SAVED_SEARCHES_KEY, []);
+  }
+  async function saveStored(list: StoredSavedSearch[]): Promise<StoredSavedSearch[]> {
+    await storageSet(SAVED_SEARCHES_KEY, list);
+    return list;
+  }
+
+  return {
+    getAnalyzedListings: () => deps.getListings(),
+    getVisibleCount: () => deps.getVisibleCount(),
+
+    getFilterState: () => currentFilterState,
+    applyFilterState: applyState,
+
+    getSort: () => deps.getSort(),
+    setSort: (id, direction) => deps.setSort(id, direction),
+
+    async loadSavedSearches() {
+      return loadStored();
+    },
+    async addSavedSearch(name: string) {
+      const list = await loadStored();
+      const item: StoredSavedSearch = {
+        id: `search-${Date.now()}`,
+        name,
+        query: currentFilterState.keywords,
+        isPinned: false,
+        createdAt: Date.now(),
+        lastRunAt: null,
+        resultCount: deps.getVisibleCount(),
+        filters: currentFilterState,
+        sortId: deps.getSort().id,
+        sortDirection: deps.getSort().direction,
+        notifications: { enabled: true, frequency: "daily" },
+      };
+      return saveStored([item, ...list]);
+    },
+    async deleteSavedSearch(id: string) {
+      const list = await loadStored();
+      return saveStored(list.filter((s) => s.id !== id));
+    },
+    async togglePinSavedSearch(id: string) {
+      const list = await loadStored();
+      return saveStored(
+        list.map((s) => (s.id === id ? { ...s, isPinned: !s.isPinned } : s)),
+      );
+    },
+    runSavedSearch(item: SavedSearchItem) {
+      const stored = item as StoredSavedSearch;
+      applyState(stored.filters ?? { ...DEFAULT_FILTERS, keywords: item.query });
+      if (stored.sortId !== undefined) {
+        deps.setSort(stored.sortId, stored.sortDirection ?? "asc");
+      }
+      // Record last-run time (best effort).
+      loadStored().then((list) =>
+        saveStored(list.map((s) => (s.id === item.id ? { ...s, lastRunAt: Date.now() } : s))),
+      );
+    },
+    async exportSavedSearches() {
+      return JSON.stringify(await loadStored(), null, 2);
+    },
+    async importSavedSearches(json: string) {
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(json);
+      } catch {
+        return loadStored();
+      }
+      if (!Array.isArray(parsed)) return loadStored();
+      const existing = await loadStored();
+      const imported = parsed
+        .filter((s): s is StoredSavedSearch => !!s && typeof s === "object" && "name" in s)
+        // Re-id imported entries to avoid collisions with existing ones.
+        .map((s, i) => ({ ...s, id: `import-${Date.now()}-${i}` }));
+      return saveStored([...existing, ...imported]);
+    },
+
+    async loadSettings() {
+      return storageGet<SettingsState>(SETTINGS_KEY, DEFAULT_SETTINGS);
+    },
+    async saveSettings(settings: SettingsState) {
+      await storageSet(SETTINGS_KEY, settings);
+    },
+
+    async loadHistory() {
+      const records = await deps.persistence.getRecentListings(50);
+      return records.map(toHistoryEntry);
+    },
+
+    // Per-card comparison selection is not wired yet; the panel shows its empty
+    // state until "add to compare" controls exist on cards.
+    getComparison: () => null,
+    getComparisonTitles: () => ({}),
+    clearComparison: () => {},
+
+    subscribe: (event, handler) => deps.subscribe(event, handler),
+  };
+}
+
+/** Handle returned by {@link mountSidebar} for teardown. */
+export interface SidebarMountHandle {
+  unmount: () => void;
+}
+
+/**
+ * Render the React sidebar into the injected host's content area, replacing the
+ * placeholder vanilla controls. Returns `null` if the host is not present.
+ */
+export function mountSidebar(controller: SidebarController): SidebarMountHandle | null {
+  const content = document.querySelector(".mps-sidebar-content");
+  if (!content) return null;
+
+  // Clear the placeholder vanilla controls and host the React root.
+  content.innerHTML = "";
+  const rootEl = document.createElement("div");
+  rootEl.id = "mps-react-root";
+  rootEl.style.height = "100%";
+  content.appendChild(rootEl);
+
+  const root: Root = createRoot(rootEl);
+  root.render(
+    <SidebarDataProvider controller={controller}>
+      <SidebarTabs />
+    </SidebarDataProvider>,
+  );
+
+  return { unmount: () => root.unmount() };
+}

--- a/src/content/styles.css
+++ b/src/content/styles.css
@@ -344,7 +344,6 @@
 }
 
 /* --- Forecast badges --- */
-
 .mps-badge-forecast-fast {
   background: var(--mps-color-forecast-fast, #1a7f37);
   color: #ffffff;
@@ -358,6 +357,28 @@
 .mps-badge-forecast-slow {
   background: var(--mps-color-forecast-slow, #6e7781);
   color: #ffffff;
+}
+
+/* --- Per-card compare toggle button --- */
+
+.mps-card-compare-btn {
+  position: absolute;
+  top: 6px;
+  left: 6px;
+  z-index: 5;
+  padding: 2px 6px;
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1.4;
+  border: none;
+  border-radius: var(--mps-radius-sm, 4px);
+  background: rgba(0, 0, 0, 0.65);
+  color: #ffffff;
+  cursor: pointer;
+}
+
+.mps-card-compare-btn[data-mps-selected="true"] {
+  background: var(--mps-color-primary, #0866ff);
 }
 
 /* ==========================================================================

--- a/src/content/styles.css
+++ b/src/content/styles.css
@@ -343,6 +343,23 @@
   color: #ffffff;
 }
 
+/* --- Forecast badges --- */
+
+.mps-badge-forecast-fast {
+  background: var(--mps-color-forecast-fast, #1a7f37);
+  color: #ffffff;
+}
+
+.mps-badge-forecast-moderate {
+  background: var(--mps-color-forecast-moderate, #9a6700);
+  color: #ffffff;
+}
+
+.mps-badge-forecast-slow {
+  background: var(--mps-color-forecast-slow, #6e7781);
+  color: #ffffff;
+}
+
 /* ==========================================================================
    Listing Visibility States
    ========================================================================== */

--- a/src/core/analysis/image-analyzer.test.ts
+++ b/src/core/analysis/image-analyzer.test.ts
@@ -1,5 +1,56 @@
 import { describe, it, expect } from 'vitest';
-import { analyzeImageHeuristic, isCommonAiResolution, isCommonAiAspectRatio } from './image-analyzer';
+import {
+  analyzeImageHeuristic,
+  isCommonAiResolution,
+  isCommonAiAspectRatio,
+  NO_EXIF_SIGNAL,
+  type ImageMetadata,
+} from './image-analyzer';
+
+/** All non-EXIF signals triggered, with EXIF present (so its signal is off). */
+const PIXEL_SIGNALS_ALL_ON: ImageMetadata = {
+  width: 1024,
+  height: 1024, // common AI resolution + 1:1 aspect
+  hasExif: true,
+  hasUniformBackground: true,
+  avgSaturation: 0.5,
+  saturationStdDev: 0.05, // uniform saturation
+  isCommonAiAspectRatio: true,
+  isCommonAiResolution: true,
+};
+
+describe('analyzeImageHeuristic — excludeSignals (EXIF renormalization)', () => {
+  it('caps at ~72 when EXIF is counted but cannot trigger (default)', () => {
+    // (20+10+20+15) / 90 = 72
+    expect(analyzeImageHeuristic(PIXEL_SIGNALS_ALL_ON).aiScore).toBe(72);
+  });
+
+  it('reaches 100 when the EXIF signal is excluded and renormalized', () => {
+    const result = analyzeImageHeuristic(PIXEL_SIGNALS_ALL_ON, {
+      excludeSignals: [NO_EXIF_SIGNAL],
+    });
+    expect(result.aiScore).toBe(100);
+    expect(result.classification).toBe('likely-ai');
+    expect(result.signals.some((s) => s.name === NO_EXIF_SIGNAL)).toBe(false);
+  });
+
+  it('no longer inflates the score for a real photo with no other signals', () => {
+    const realPhoto: ImageMetadata = {
+      width: 3024,
+      height: 4032,
+      hasExif: false, // would trigger the 25-weight no-EXIF signal
+      hasUniformBackground: false,
+      avgSaturation: 0.4,
+      saturationStdDev: 0.3,
+      isCommonAiAspectRatio: false,
+      isCommonAiResolution: false,
+    };
+    expect(analyzeImageHeuristic(realPhoto).aiScore).toBe(28); // 25/90
+    expect(
+      analyzeImageHeuristic(realPhoto, { excludeSignals: [NO_EXIF_SIGNAL] }).aiScore,
+    ).toBe(0);
+  });
+});
 
 describe('isCommonAiResolution', () => {
   it('returns true for known AI resolutions', () => {

--- a/src/core/analysis/image-analyzer.ts
+++ b/src/core/analysis/image-analyzer.ts
@@ -111,14 +111,31 @@ export function isCommonAiAspectRatio(width: number, height: number): boolean {
  * // result.classification => 'possibly-ai'
  * ```
  */
-export function analyzeImageHeuristic(metadata: ImageMetadata): AiDetectionResult {
+/** Display name of the EXIF signal (also used to exclude it where uninformative). */
+export const NO_EXIF_SIGNAL = 'No EXIF metadata';
+
+/** Options for {@link analyzeImageHeuristic}. */
+export interface HeuristicOptions {
+  /**
+   * Signal names to exclude from the score; the remaining signals are
+   * renormalized to 0-100. Used where a signal carries no information for the
+   * source (e.g. Facebook strips EXIF from every upload, so {@link NO_EXIF_SIGNAL}
+   * would fire universally and inflate the score).
+   */
+  excludeSignals?: readonly string[];
+}
+
+export function analyzeImageHeuristic(
+  metadata: ImageMetadata,
+  options: HeuristicOptions = {},
+): AiDetectionResult {
   const signals: AiSignal[] = [];
   let totalWeight = 0;
   let triggeredWeight = 0;
 
   // Signal 1: No EXIF data (real photos usually have EXIF)
   const noExif: AiSignal = {
-    name: 'No EXIF metadata',
+    name: NO_EXIF_SIGNAL,
     description: 'Real camera photos typically contain EXIF data (camera model, exposure, etc.)',
     weight: 25,
     triggered: !metadata.hasExif,
@@ -171,6 +188,22 @@ export function analyzeImageHeuristic(metadata: ImageMetadata): AiDetectionResul
   totalWeight += uniformBg.weight;
   if (uniformBg.triggered) triggeredWeight += uniformBg.weight;
 
+  // Exclude any uninformative signals and renormalize over the rest, so the
+  // score still spans the full 0-100 range (rather than being capped by the
+  // excluded weight).
+  const excluded = new Set(options.excludeSignals ?? []);
+  if (excluded.size > 0) {
+    for (const s of signals) {
+      if (excluded.has(s.name)) {
+        totalWeight -= s.weight;
+        if (s.triggered) triggeredWeight -= s.weight;
+      }
+    }
+  }
+  const reportedSignals = excluded.size > 0
+    ? signals.filter((s) => !excluded.has(s.name))
+    : signals;
+
   // Calculate score
   const aiScore = totalWeight > 0 ? Math.round((triggeredWeight / totalWeight) * 100) : 0;
 
@@ -181,11 +214,11 @@ export function analyzeImageHeuristic(metadata: ImageMetadata): AiDetectionResul
   else classification = 'likely-ai';
 
   // Confidence based on how many signals were evaluable
-  const evaluableSignals = signals.length;
+  const evaluableSignals = reportedSignals.length;
   let confidence: 'high' | 'medium' | 'low';
   if (evaluableSignals >= 4) confidence = 'medium'; // Heuristic-only can never be "high"
   else if (evaluableSignals >= 2) confidence = 'low';
   else confidence = 'low';
 
-  return { aiScore, classification, signals, confidence };
+  return { aiScore, classification, signals: reportedSignals, confidence };
 }

--- a/src/core/analysis/seller-trust.test.ts
+++ b/src/core/analysis/seller-trust.test.ts
@@ -23,6 +23,12 @@ describe('calculateTrustScore', () => {
     expect(result.dataPointCount).toBeGreaterThanOrEqual(5);
   });
 
+  it('scores response from the qualitative description', () => {
+    const result = calculateTrustScore({ responseDescription: 'Very responsive' });
+    expect(result.breakdown.response).toBe(10);
+    expect(result.factorsWithData).toContain('response');
+  });
+
   it('scores account age correctly', () => {
     // < 3 months = 0 points
     const young = calculateTrustScore({ accountAgeDays: 30 });

--- a/src/core/analysis/seller-trust.ts
+++ b/src/core/analysis/seller-trust.ts
@@ -202,7 +202,11 @@ export function calculateTrustScore(profile: Partial<SellerProfile>): TrustScore
     : null;
   const ratingValue = profile.rating?.overall ?? null;
   const ratingCount = profile.rating?.totalReviews ?? null;
-  const responseRateStr = profile.responseRate != null ? String(profile.responseRate) : null;
+  // Prefer the qualitative description Facebook actually shows (what the
+  // scorer phrase-matches on); fall back to stringifying a numeric rate.
+  const responseRateStr =
+    profile.responseDescription ??
+    (profile.responseRate != null ? String(profile.responseRate) : null);
 
   const factors: { name: string; result: { score: number; hasData: boolean } }[] = [
     { name: 'accountAge', result: scoreAccountAge(accountAgeMonths) },

--- a/src/core/models/seller.ts
+++ b/src/core/models/seller.ts
@@ -114,6 +114,14 @@ export interface SellerProfile {
   readonly responseRate: number | null;
 
   /**
+   * Qualitative responsiveness description as shown by Facebook
+   * (e.g. "Very responsive"). This is what the trust scorer phrase-matches on,
+   * since Facebook exposes responsiveness as text rather than a number.
+   * `null` if unavailable.
+   */
+  readonly responseDescription: string | null;
+
+  /**
    * Typical response time in minutes. `null` if unavailable.
    *
    * @example 30  // responds within 30 minutes
@@ -187,6 +195,9 @@ export interface SellerProfileInput {
   /** @see SellerProfile.responseRate */
   readonly responseRate?: number | null;
 
+  /** @see SellerProfile.responseDescription */
+  readonly responseDescription?: string | null;
+
   /** @see SellerProfile.responseTime */
   readonly responseTime?: number | null;
 
@@ -251,6 +262,7 @@ export function createSellerProfile(input: SellerProfileInput): SellerProfile {
       negativeCount: input.rating?.negativeCount ?? null,
     },
     responseRate: input.responseRate ?? null,
+    responseDescription: input.responseDescription ?? null,
     responseTime: input.responseTime ?? null,
     profileCompleteness: input.profileCompleteness ?? "unknown",
     trustScore: input.trustScore ?? null,

--- a/src/ui/sidebar/ComparisonView.tsx
+++ b/src/ui/sidebar/ComparisonView.tsx
@@ -9,8 +9,8 @@ import React, { useState, useCallback } from 'react';
 import { PanelLayout } from '@/design-system/layouts/PanelLayout';
 import { ComparisonRow } from '@/design-system/composites/ComparisonRow';
 import { Button } from '@/design-system/primitives/Button';
-import type { ComparisonResult } from '@/core/analysis/comparison-engine';
 import { formatAsMarkdown, formatAsText } from '@/core/utils/comparison-export';
+import { useSidebarData } from '@/ui/sidebar/sidebar-context';
 
 /** Props for the {@link ComparisonView} component. */
 export interface ComparisonViewProps {
@@ -29,9 +29,7 @@ export interface ComparisonViewProps {
  * ```
  */
 export const ComparisonView: React.FC<ComparisonViewProps> = ({ className }) => {
-  // In production this would come from a comparison store/context
-  const [comparison] = useState<ComparisonResult | null>(null);
-  const [listingTitles] = useState<Record<string, string>>({});
+  const { comparison, comparisonTitles: listingTitles, clearComparison } = useSidebarData();
   const [copied, setCopied] = useState(false);
 
   const copyAsMarkdown = useCallback(() => {
@@ -127,7 +125,7 @@ export const ComparisonView: React.FC<ComparisonViewProps> = ({ className }) => 
       title="Compare"
       className={className}
       actions={
-        <Button variant="ghost" size="sm">
+        <Button variant="ghost" size="sm" onClick={clearComparison}>
           Clear
         </Button>
       }

--- a/src/ui/sidebar/FilterPanel.tsx
+++ b/src/ui/sidebar/FilterPanel.tsx
@@ -7,51 +7,11 @@
  * @module ui/sidebar/FilterPanel
  */
 
-import React, { useState, useCallback } from 'react';
+import React, { useCallback } from 'react';
 import { PanelLayout } from '@/design-system/layouts/PanelLayout';
 import { FilterGroup } from '@/design-system/composites/FilterGroup';
 import { Button } from '@/design-system/primitives/Button';
-
-/** Internal state shape for all filter controls. */
-interface FilterState {
-  keywords: string;
-  excludeKeywords: string;
-  priceMin: string;
-  priceMax: string;
-  maxDistance: string;
-  conditions: Record<string, boolean>;
-  datePosted: string;
-  minTrustScore: string;
-  minImageQuality: string;
-  priceRatingTiers: Record<string, boolean>;
-}
-
-const DEFAULT_FILTERS: FilterState = {
-  keywords: '',
-  excludeKeywords: '',
-  priceMin: '',
-  priceMax: '',
-  maxDistance: '',
-  conditions: {
-    new: false,
-    like_new: false,
-    good: false,
-    fair: false,
-    salvage: false,
-  },
-  datePosted: 'any',
-  minTrustScore: '',
-  minImageQuality: '',
-  priceRatingTiers: {
-    steal: false,
-    'great-deal': false,
-    'good-price': false,
-    'fair-price': false,
-    'above-market': false,
-    high: false,
-    overpriced: false,
-  },
-};
+import { useSidebarData, DEFAULT_FILTERS, type FilterState } from '@/ui/sidebar/sidebar-context';
 
 const CONDITION_LABELS: Record<string, string> = {
   new: 'New',
@@ -128,30 +88,42 @@ const fieldGap: React.CSSProperties = { marginBottom: 'var(--mps-spacing-sm)' };
  * ```
  */
 export const FilterPanel: React.FC<{ className?: string }> = ({ className }) => {
-  const [filters, setFilters] = useState<FilterState>(DEFAULT_FILTERS);
+  const { filterState: filters, setFilterState } = useSidebarData();
 
   const updateField = useCallback(
     <K extends keyof FilterState>(field: K, value: FilterState[K]) => {
-      setFilters((prev) => ({ ...prev, [field]: value }));
+      setFilterState({ ...filters, [field]: value });
     },
-    [],
+    [filters, setFilterState],
   );
 
-  const toggleCondition = useCallback((key: string) => {
-    setFilters((prev) => ({
-      ...prev,
-      conditions: { ...prev.conditions, [key]: !prev.conditions[key] },
-    }));
-  }, []);
+  const toggleCondition = useCallback(
+    (key: string) => {
+      setFilterState({
+        ...filters,
+        conditions: { ...filters.conditions, [key]: !filters.conditions[key] },
+      });
+    },
+    [filters, setFilterState],
+  );
 
-  const togglePriceRating = useCallback((key: string) => {
-    setFilters((prev) => ({
-      ...prev,
-      priceRatingTiers: { ...prev.priceRatingTiers, [key]: !prev.priceRatingTiers[key] },
-    }));
-  }, []);
+  const togglePriceRating = useCallback(
+    (key: string) => {
+      setFilterState({
+        ...filters,
+        priceRatingTiers: {
+          ...filters.priceRatingTiers,
+          [key]: !filters.priceRatingTiers[key],
+        },
+      });
+    },
+    [filters, setFilterState],
+  );
 
-  const resetFilters = useCallback(() => setFilters(DEFAULT_FILTERS), []);
+  const resetFilters = useCallback(
+    () => setFilterState(DEFAULT_FILTERS),
+    [setFilterState],
+  );
 
   const activeCount = (): number => {
     let count = 0;

--- a/src/ui/sidebar/FilterPanel.tsx
+++ b/src/ui/sidebar/FilterPanel.tsx
@@ -7,11 +7,20 @@
  * @module ui/sidebar/FilterPanel
  */
 
-import React, { useCallback } from 'react';
+import React, { useCallback, useState } from 'react';
 import { PanelLayout } from '@/design-system/layouts/PanelLayout';
 import { FilterGroup } from '@/design-system/composites/FilterGroup';
 import { Button } from '@/design-system/primitives/Button';
 import { useSidebarData, DEFAULT_FILTERS, type FilterState } from '@/ui/sidebar/sidebar-context';
+
+/** Read the current Marketplace search query from the page URL, if any. */
+function initialSearchQuery(): string {
+  try {
+    return new URLSearchParams(window.location.search).get('query') ?? '';
+  } catch {
+    return '';
+  }
+}
 
 const CONDITION_LABELS: Record<string, string> = {
   new: 'New',
@@ -89,6 +98,16 @@ const fieldGap: React.CSSProperties = { marginBottom: 'var(--mps-spacing-sm)' };
  */
 export const FilterPanel: React.FC<{ className?: string }> = ({ className }) => {
   const { filterState: filters, setFilterState } = useSidebarData();
+  const [searchQuery, setSearchQuery] = useState<string>(initialSearchQuery);
+
+  // Navigates Facebook to a new Marketplace search. Unlike the keyword filter
+  // (which narrows already-loaded listings), this loads a fresh result set.
+  const navigateSearch = useCallback(() => {
+    const q = searchQuery.trim();
+    if (q) {
+      window.location.href = `https://www.facebook.com/marketplace/search/?query=${encodeURIComponent(q)}`;
+    }
+  }, [searchQuery]);
 
   const updateField = useCallback(
     <K extends keyof FilterState>(field: K, value: FilterState[K]) => {
@@ -149,6 +168,27 @@ export const FilterPanel: React.FC<{ className?: string }> = ({ className }) => 
         </Button>
       }
     >
+      {/* Search Marketplace (navigates to a fresh FB search) */}
+      <div style={{ ...rowStyle, ...fieldGap }}>
+        <input
+          type="text"
+          style={inputStyle}
+          placeholder="Search Marketplace…"
+          aria-label="Search Facebook Marketplace"
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault();
+              navigateSearch();
+            }
+          }}
+        />
+        <Button size="sm" onClick={navigateSearch} disabled={!searchQuery.trim()}>
+          Search
+        </Button>
+      </div>
+
       {/* Keywords */}
       <FilterGroup label="Keywords" defaultExpanded>
         <div style={fieldGap}>

--- a/src/ui/sidebar/HeatMap.tsx
+++ b/src/ui/sidebar/HeatMap.tsx
@@ -6,23 +6,11 @@
  * @module ui/sidebar/HeatMap
  */
 
-import React, { useState } from 'react';
+import React from 'react';
+import { useSidebarData } from '@/ui/sidebar/sidebar-context';
 import { PanelLayout } from '@/design-system/layouts/PanelLayout';
 import { HeatIndicator } from '@/design-system/composites/HeatIndicator';
-import { HEAT_TIER_INFO, type HeatTier } from '@/core/analysis/heat-tracker';
-
-/** A listing's heat data for display. */
-interface HeatEntry {
-  listingId: string;
-  title: string;
-  price: number | null;
-  imageUrl: string | null;
-  score: number;
-  tier: HeatTier;
-  saves: number | null;
-  comments: number | null;
-  views: number | null;
-}
+import { HEAT_TIER_INFO } from '@/core/analysis/heat-tracker';
 
 /** Props for the {@link HeatMap} component. */
 export interface HeatMapProps {
@@ -40,8 +28,7 @@ export interface HeatMapProps {
  * ```
  */
 export const HeatMap: React.FC<HeatMapProps> = ({ className }) => {
-  // In production this would come from a context/store
-  const [entries] = useState<HeatEntry[]>([]);
+  const { heatEntries: entries } = useSidebarData();
 
   const emptyStyle: React.CSSProperties = {
     textAlign: 'center',

--- a/src/ui/sidebar/ImageAnalysisPanel.tsx
+++ b/src/ui/sidebar/ImageAnalysisPanel.tsx
@@ -6,28 +6,13 @@
  * @module ui/sidebar/ImageAnalysisPanel
  */
 
-import React, { useState } from 'react';
+import React from 'react';
+import { useSidebarData } from '@/ui/sidebar/sidebar-context';
 import { PanelLayout } from '@/design-system/layouts/PanelLayout';
 import { ImageFlagBadge } from '@/design-system/composites/ImageFlagBadge';
 import { ConfidenceBar } from '@/design-system/composites/ConfidenceBar';
 import { Badge } from '@/design-system/primitives/Badge';
 
-/** A flagged image entry for display. */
-interface FlaggedImage {
-  listingId: string;
-  listingTitle: string;
-  imageUrl: string;
-  classification: string;
-  aiScore: number;
-  confidence: 'high' | 'medium' | 'low';
-  signalCount: number;
-  /** Whether ML model was used for this analysis */
-  mlModelUsed?: boolean;
-  /** ML model confidence score (0-1), if model was used */
-  mlScore?: number;
-  /** Inference time in milliseconds */
-  inferenceTimeMs?: number;
-}
 
 /** Props for the {@link ImageAnalysisPanel} component. */
 export interface ImageAnalysisPanelProps {
@@ -46,8 +31,7 @@ export interface ImageAnalysisPanelProps {
  * ```
  */
 export const ImageAnalysisPanel: React.FC<ImageAnalysisPanelProps> = ({ className }) => {
-  // In production this would come from a context/store
-  const [flaggedImages] = useState<FlaggedImage[]>([]);
+  const { flaggedImages } = useSidebarData();
 
   const emptyStyle: React.CSSProperties = {
     textAlign: 'center',

--- a/src/ui/sidebar/ListingHistory.tsx
+++ b/src/ui/sidebar/ListingHistory.tsx
@@ -5,20 +5,11 @@
  * @module ui/sidebar/ListingHistory
  */
 
-import React, { useState, useCallback } from 'react';
+import React, { useCallback } from 'react';
+import { useSidebarData } from '@/ui/sidebar/sidebar-context';
 import { PanelLayout } from '@/design-system/layouts/PanelLayout';
 import { Button } from '@/design-system/primitives/Button';
 
-/** A history entry for display. */
-interface HistoryEntry {
-  listingId: string;
-  title: string;
-  price: number | null;
-  imageUrl: string | null;
-  firstSeen: number;
-  lastSeen: number;
-  viewCount: number;
-}
 
 /** Props for the {@link ListingHistory} component. */
 export interface ListingHistoryProps {
@@ -37,8 +28,7 @@ export interface ListingHistoryProps {
  * ```
  */
 export const ListingHistory: React.FC<ListingHistoryProps> = ({ className }) => {
-  // In production this would come from a context/store
-  const [entries] = useState<HistoryEntry[]>([]);
+  const { historyEntries: entries } = useSidebarData();
 
   const handleMarkAllSeen = useCallback(() => {
     // In production: dispatch action

--- a/src/ui/sidebar/PriceAnalytics.tsx
+++ b/src/ui/sidebar/PriceAnalytics.tsx
@@ -5,22 +5,11 @@
  * @module ui/sidebar/PriceAnalytics
  */
 
-import React, { useState } from 'react';
+import React from 'react';
 import { PanelLayout } from '@/design-system/layouts/PanelLayout';
 import { ConfidenceBar } from '@/design-system/composites/ConfidenceBar';
 import { PRICE_RATING_INFO, type PriceRatingTier } from '@/core/analysis/price-rater';
-
-/** Aggregated price statistics. */
-interface PriceStats {
-  count: number;
-  min: number;
-  max: number;
-  mean: number;
-  median: number;
-}
-
-/** Distribution count per price rating tier. */
-type RatingDistribution = Record<PriceRatingTier, number>;
+import { useSidebarData } from '@/ui/sidebar/sidebar-context';
 
 /** Props for the {@link PriceAnalytics} component. */
 export interface PriceAnalyticsProps {
@@ -50,18 +39,11 @@ const TIER_ORDER: PriceRatingTier[] = [
  * ```
  */
 export const PriceAnalytics: React.FC<PriceAnalyticsProps> = ({ className }) => {
-  // In production these would come from a context/store
-  const [stats] = useState<PriceStats>({ count: 0, min: 0, max: 0, mean: 0, median: 0 });
-  const [distribution] = useState<RatingDistribution>({
-    steal: 0,
-    'great-deal': 0,
-    'good-price': 0,
-    'fair-price': 0,
-    'above-market': 0,
-    high: 0,
-    overpriced: 0,
-  });
-  const [confidence] = useState<'high' | 'medium' | 'low' | 'insufficient'>('insufficient');
+  const {
+    priceStats: stats,
+    ratingDistribution: distribution,
+    priceConfidence: confidence,
+  } = useSidebarData();
 
   const statGridStyle: React.CSSProperties = {
     display: 'grid',

--- a/src/ui/sidebar/SalesForecast.tsx
+++ b/src/ui/sidebar/SalesForecast.tsx
@@ -5,7 +5,8 @@
  * @module ui/sidebar/SalesForecast
  */
 
-import React, { useState, useMemo } from 'react';
+import React, { useMemo } from 'react';
+import { useSidebarData } from '@/ui/sidebar/sidebar-context';
 import { PanelLayout } from '@/design-system/layouts/PanelLayout';
 import { ForecastIndicator } from '@/design-system/composites/ForecastIndicator';
 // ConfidenceBar available for future per-listing confidence display
@@ -38,8 +39,7 @@ export interface SalesForecastProps {
  * ```
  */
 export const SalesForecast: React.FC<SalesForecastProps> = ({ className }) => {
-  // In production this would come from a context/store
-  const [entries] = useState<ForecastEntry[]>([]);
+  const { forecastEntries: entries } = useSidebarData();
 
   const actFast = useMemo(
     () => entries.filter((e) => e.urgency === 'act-fast').sort((a, b) => a.estimatedDays - b.estimatedDays),

--- a/src/ui/sidebar/SavedSearches.tsx
+++ b/src/ui/sidebar/SavedSearches.tsx
@@ -6,20 +6,10 @@
  * @module ui/sidebar/SavedSearches
  */
 
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useRef } from 'react';
 import { PanelLayout } from '@/design-system/layouts/PanelLayout';
 import { Button } from '@/design-system/primitives/Button';
-
-/** Local representation of a saved search for the UI. */
-interface SavedSearchItem {
-  id: string;
-  name: string;
-  query: string;
-  isPinned: boolean;
-  createdAt: number;
-  lastRunAt: number | null;
-  resultCount: number | null;
-}
+import { useSidebarData } from '@/ui/sidebar/sidebar-context';
 
 /** Props for the {@link SavedSearches} component. */
 export interface SavedSearchesProps {
@@ -37,14 +27,45 @@ export interface SavedSearchesProps {
  * ```
  */
 export const SavedSearches: React.FC<SavedSearchesProps> = ({ className }) => {
-  const [searches] = useState<SavedSearchItem[]>([]);
+  const {
+    savedSearches: searches,
+    addSavedSearch,
+    deleteSavedSearch,
+    togglePinSavedSearch,
+    runSavedSearch,
+    exportSavedSearches,
+    importSavedSearches,
+  } = useSidebarData();
   const [newName, setNewName] = useState('');
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   const handleSave = useCallback(() => {
     if (!newName.trim()) return;
-    // In production: dispatch save action via event bus / store
+    addSavedSearch(newName.trim());
     setNewName('');
-  }, [newName]);
+  }, [newName, addSavedSearch]);
+
+  const handleExport = useCallback(async () => {
+    const json = await exportSavedSearches();
+    const blob = new Blob([json], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'marketplacesucks-saved-searches.json';
+    a.click();
+    URL.revokeObjectURL(url);
+  }, [exportSavedSearches]);
+
+  const handleImportFile = useCallback(
+    async (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      if (!file) return;
+      const text = await file.text();
+      importSavedSearches(text);
+      e.target.value = '';
+    },
+    [importSavedSearches],
+  );
 
   const inputStyle: React.CSSProperties = {
     flex: 1,
@@ -153,9 +174,11 @@ export const SavedSearches: React.FC<SavedSearchesProps> = ({ className }) => {
                 </div>
               </div>
               <div style={{ display: 'flex', gap: 'var(--mps-spacing-xxs)' }}>
-                <Button variant="ghost" size="sm">Load</Button>
-                <Button variant="ghost" size="sm">{search.isPinned ? 'Unpin' : 'Pin'}</Button>
-                <Button variant="danger" size="sm">Delete</Button>
+                <Button variant="ghost" size="sm" onClick={() => runSavedSearch(search)}>Load</Button>
+                <Button variant="ghost" size="sm" onClick={() => togglePinSavedSearch(search.id)}>
+                  {search.isPinned ? 'Unpin' : 'Pin'}
+                </Button>
+                <Button variant="danger" size="sm" onClick={() => deleteSavedSearch(search.id)}>Delete</Button>
               </div>
             </div>
           ))}
@@ -164,8 +187,19 @@ export const SavedSearches: React.FC<SavedSearchesProps> = ({ className }) => {
 
       {/* Export / Import */}
       <div style={footerStyle}>
-        <Button variant="ghost" size="sm">Export as JSON</Button>
-        <Button variant="ghost" size="sm">Import</Button>
+        <Button variant="ghost" size="sm" onClick={handleExport} disabled={searches.length === 0}>
+          Export as JSON
+        </Button>
+        <Button variant="ghost" size="sm" onClick={() => fileInputRef.current?.click()}>
+          Import
+        </Button>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="application/json"
+          style={{ display: 'none' }}
+          onChange={handleImportFile}
+        />
       </div>
     </PanelLayout>
   );

--- a/src/ui/sidebar/SellerTrustPanel.tsx
+++ b/src/ui/sidebar/SellerTrustPanel.tsx
@@ -5,11 +5,12 @@
  * @module ui/sidebar/SellerTrustPanel
  */
 
-import React, { useState } from 'react';
+import React from 'react';
 import { PanelLayout } from '@/design-system/layouts/PanelLayout';
 import { TrustBadge } from '@/design-system/composites/TrustBadge';
 import { ConfidenceBar } from '@/design-system/composites/ConfidenceBar';
 import { TRUST_FACTOR_MAX_SCORES, type TrustScoreBreakdown } from '@/core/analysis/seller-trust';
+import { useSidebarData } from '@/ui/sidebar/sidebar-context';
 
 /** Displayable trust data for the panel. */
 interface TrustDisplayData {
@@ -47,8 +48,9 @@ const FACTOR_LABELS: Record<keyof TrustScoreBreakdown, string> = {
  * ```
  */
 export const SellerTrustPanel: React.FC<SellerTrustPanelProps> = ({ className }) => {
-  // In production this would come from a context/store; placeholder for now
-  const [trustData] = useState<TrustDisplayData | null>(null);
+  // Show the trust details of the first scored seller currently in view.
+  const { trustList } = useSidebarData();
+  const trustData: TrustDisplayData | null = trustList[0] ?? null;
 
   const containerStyle: React.CSSProperties = {
     padding: 'var(--mps-spacing-md)',

--- a/src/ui/sidebar/Settings.tsx
+++ b/src/ui/sidebar/Settings.tsx
@@ -5,9 +5,10 @@
  * @module ui/sidebar/Settings
  */
 
-import React, { useState, useCallback } from 'react';
+import React, { useCallback } from 'react';
 import { PanelLayout } from '@/design-system/layouts/PanelLayout';
 import { Button } from '@/design-system/primitives/Button';
+import { useSidebarData } from '@/ui/sidebar/sidebar-context';
 
 /** All user-configurable settings. */
 interface SettingsState {
@@ -122,18 +123,18 @@ const toggleKnobStyle = (checked: boolean): React.CSSProperties => ({
  * ```
  */
 export const Settings: React.FC<SettingsProps> = ({ className }) => {
-  const [settings, setSettings] = useState<SettingsState>(DEFAULT_SETTINGS);
+  const { settings, saveSettings } = useSidebarData();
 
   const update = useCallback(
     <K extends keyof SettingsState>(key: K, value: SettingsState[K]) => {
-      setSettings((prev) => ({ ...prev, [key]: value }));
+      saveSettings({ ...settings, [key]: value });
     },
-    [],
+    [settings, saveSettings],
   );
 
   const handleReset = useCallback(() => {
-    setSettings(DEFAULT_SETTINGS);
-  }, []);
+    saveSettings(DEFAULT_SETTINGS);
+  }, [saveSettings]);
 
   /** Toggle switch sub-component. */
   const Toggle: React.FC<{

--- a/src/ui/sidebar/Sidebar.tsx
+++ b/src/ui/sidebar/Sidebar.tsx
@@ -78,11 +78,13 @@ export interface SidebarProps {
  * <Sidebar isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} />
  * ```
  */
-export const Sidebar: React.FC<SidebarProps> = ({
-  isOpen,
-  onClose,
+/**
+ * The tab bar + active panel, without the {@link SidebarLayout} shell. Used
+ * when embedding inside the content script's injected sidebar host, which
+ * already provides the header/collapse chrome.
+ */
+export const SidebarTabs: React.FC<{ defaultTab?: SidebarTabId }> = ({
   defaultTab = 'filters',
-  className,
 }) => {
   const [activeTab, setActiveTab] = useState<SidebarTabId>(defaultTab);
 
@@ -146,7 +148,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
   };
 
   return (
-    <SidebarLayout isOpen={isOpen} onClose={onClose} className={className}>
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
       <nav style={tabBarStyle} role="tablist" aria-label="Sidebar tabs">
         {TABS.map((tab) => (
           <button
@@ -170,6 +172,21 @@ export const Sidebar: React.FC<SidebarProps> = ({
       >
         {panelMap[activeTab]}
       </div>
-    </SidebarLayout>
+    </div>
   );
 };
+
+/**
+ * Top-level sidebar component that renders the tab bar and active panel inside
+ * the {@link SidebarLayout} shell. Retained for standalone/full-shell usage.
+ */
+export const Sidebar: React.FC<SidebarProps> = ({
+  isOpen,
+  onClose,
+  defaultTab = 'filters',
+  className,
+}) => (
+  <SidebarLayout isOpen={isOpen} onClose={onClose} className={className}>
+    <SidebarTabs defaultTab={defaultTab} />
+  </SidebarLayout>
+);

--- a/src/ui/sidebar/SortPanel.tsx
+++ b/src/ui/sidebar/SortPanel.tsx
@@ -5,14 +5,38 @@
  * @module ui/sidebar/SortPanel
  */
 
-import React, { useState, useCallback } from 'react';
+import React, { useCallback } from 'react';
 import { PanelLayout } from '@/design-system/layouts/PanelLayout';
+import { useSidebarData } from '@/ui/sidebar/sidebar-context';
 
 /** A single sort option definition. */
 interface SortOption {
   id: string;
   label: string;
   description: string;
+}
+
+/** Maps a UI sort option to the sorter-registry id + direction it drives. */
+const SORT_MAP: Record<string, { sorterId: string; direction: 'asc' | 'desc' }> = {
+  'price-asc': { sorterId: 'price', direction: 'asc' },
+  'price-desc': { sorterId: 'price', direction: 'desc' },
+  'date-desc': { sorterId: 'date', direction: 'desc' },
+  'date-asc': { sorterId: 'date', direction: 'asc' },
+  'distance-asc': { sorterId: 'distance', direction: 'asc' },
+  'alpha-asc': { sorterId: 'alphabetical', direction: 'asc' },
+  'trust-desc': { sorterId: 'seller-trust', direction: 'desc' },
+  'price-rating': { sorterId: 'price-rating', direction: 'asc' },
+  'heat-desc': { sorterId: 'heat', direction: 'desc' },
+  'forecast-asc': { sorterId: 'selling-speed', direction: 'asc' },
+};
+
+/** Resolve the current sorter id+direction back to its UI option id. */
+function uiIdFromSort(sort: { id: string | null; direction: 'asc' | 'desc' }): string {
+  if (!sort.id) return '';
+  const match = Object.entries(SORT_MAP).find(
+    ([, m]) => m.sorterId === sort.id && m.direction === sort.direction,
+  );
+  return match ? match[0] : '';
 }
 
 /** Available sort options in display order. */
@@ -45,11 +69,16 @@ export interface SortPanelProps {
  * ```
  */
 export const SortPanel: React.FC<SortPanelProps> = ({ className }) => {
-  const [selectedSort, setSelectedSort] = useState<string>('date-desc');
+  const { sort, setSort } = useSidebarData();
+  const selectedSort = uiIdFromSort(sort);
 
-  const handleSelect = useCallback((id: string) => {
-    setSelectedSort(id);
-  }, []);
+  const handleSelect = useCallback(
+    (id: string) => {
+      const mapping = SORT_MAP[id];
+      if (mapping) setSort(mapping.sorterId, mapping.direction);
+    },
+    [setSort],
+  );
 
   const optionStyle = (isSelected: boolean): React.CSSProperties => ({
     display: 'flex',

--- a/src/ui/sidebar/sidebar-context.tsx
+++ b/src/ui/sidebar/sidebar-context.tsx
@@ -1,0 +1,607 @@
+/**
+ * @module ui/sidebar/sidebar-context
+ *
+ * Single source of truth that connects the React sidebar panels to the running
+ * content-script pipeline. Previously every panel held its own mock `useState`
+ * and rendered empty/zeroed data; this context replaces that with live data
+ * derived from the analyzed listings the pipeline produces.
+ *
+ * The content script supplies an imperative {@link SidebarController} (its seam
+ * onto the filter/sort engines, persistence repositories and event bus). The
+ * {@link SidebarDataProvider} subscribes to pipeline events, recomputes the
+ * per-panel view-models, and exposes them (plus actions) through
+ * {@link useSidebarData}.
+ *
+ * View-model type definitions live here so panels and the controller share one
+ * shape.
+ */
+
+import React, {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  useMemo,
+  useCallback,
+  type ReactNode,
+} from "react";
+import type { AnalyzedListing } from "@/core/models/analyzed-listing";
+import type { ComparisonResult } from "@/core/analysis/comparison-engine";
+import type { TrustScoreBreakdown } from "@/core/analysis/seller-trust";
+import type { HeatTier } from "@/core/analysis/heat-tracker";
+import type { PriceRatingTier } from "@/core/analysis/price-rater";
+import { MPS_EVENTS } from "@/core/utils/event-bus";
+
+// ---------------------------------------------------------------------------
+// View-model types (shared by panels)
+// ---------------------------------------------------------------------------
+
+/** UI filter state edited by the FilterPanel. */
+export interface FilterState {
+  keywords: string;
+  excludeKeywords: string;
+  priceMin: string;
+  priceMax: string;
+  maxDistance: string;
+  conditions: Record<string, boolean>;
+  datePosted: string;
+  minTrustScore: string;
+  minImageQuality: string;
+  priceRatingTiers: Record<string, boolean>;
+}
+
+export const DEFAULT_FILTERS: FilterState = {
+  keywords: "",
+  excludeKeywords: "",
+  priceMin: "",
+  priceMax: "",
+  maxDistance: "",
+  conditions: { new: false, like_new: false, good: false, fair: false, salvage: false },
+  datePosted: "any",
+  minTrustScore: "",
+  minImageQuality: "",
+  priceRatingTiers: {
+    steal: false,
+    "great-deal": false,
+    "good-price": false,
+    "fair-price": false,
+    "above-market": false,
+    high: false,
+    overpriced: false,
+  },
+};
+
+export interface PriceStats {
+  count: number;
+  min: number;
+  max: number;
+  mean: number;
+  median: number;
+}
+
+export type RatingDistribution = Record<PriceRatingTier, number>;
+
+export interface TrustDisplayData {
+  sellerName: string;
+  score: number;
+  tier: string;
+  confidence: "high" | "medium" | "low" | "insufficient";
+  breakdown: TrustScoreBreakdown;
+  factorsWithData: string[];
+}
+
+export interface FlaggedImage {
+  listingId: string;
+  listingTitle: string;
+  imageUrl: string;
+  classification: string;
+  aiScore: number;
+  confidence: "high" | "medium" | "low";
+  signalCount: number;
+  /** Whether an ML model was used for this analysis. */
+  mlModelUsed?: boolean;
+  /** ML model confidence score (0-1), if a model was used. */
+  mlScore?: number;
+  /** Inference time in milliseconds. */
+  inferenceTimeMs?: number;
+}
+
+export interface HeatEntry {
+  listingId: string;
+  title: string;
+  price: number | null;
+  imageUrl: string | null;
+  score: number;
+  tier: HeatTier;
+  saves: number | null;
+  comments: number | null;
+  views: number | null;
+}
+
+export interface ForecastEntry {
+  listingId: string;
+  title: string;
+  price: number | null;
+  displayEstimate: string;
+  urgency: "act-fast" | "moderate" | "take-your-time";
+  confidence: "high" | "medium" | "low" | "insufficient";
+  estimatedDays: number;
+}
+
+export interface HistoryEntry {
+  listingId: string;
+  title: string;
+  price: number | null;
+  imageUrl: string | null;
+  firstSeen: number;
+  lastSeen: number;
+  viewCount: number;
+}
+
+export interface SavedSearchItem {
+  id: string;
+  name: string;
+  query: string;
+  isPinned: boolean;
+  createdAt: number;
+  lastRunAt: number | null;
+  resultCount: number | null;
+}
+
+export interface SettingsState {
+  theme: "auto" | "light" | "dark";
+  hiddenListingBehavior: "hide" | "dim";
+  historyRetentionDays: number;
+  priceDataRetentionDays: number;
+  enableSellerTrust: boolean;
+  enablePriceRating: boolean;
+  enableImageAnalysis: boolean;
+  enableHeatTracking: boolean;
+  enableSalesForecast: boolean;
+  enableListingHistory: boolean;
+  autoScanImages: boolean;
+}
+
+export const DEFAULT_SETTINGS: SettingsState = {
+  theme: "auto",
+  hiddenListingBehavior: "dim",
+  historyRetentionDays: 30,
+  priceDataRetentionDays: 90,
+  enableSellerTrust: true,
+  enablePriceRating: true,
+  enableImageAnalysis: false,
+  enableHeatTracking: true,
+  enableSalesForecast: true,
+  enableListingHistory: true,
+  autoScanImages: false,
+};
+
+// ---------------------------------------------------------------------------
+// Controller (imperative bridge implemented by the content script)
+// ---------------------------------------------------------------------------
+
+/**
+ * The content script's seam onto the running pipeline. The provider calls
+ * these to read live state and to drive the filter/sort engines and storage.
+ */
+export interface SidebarController {
+  /** Current analyzed listings known to the pipeline. */
+  getAnalyzedListings(): AnalyzedListing[];
+  /** Number of listings currently visible after filtering. */
+  getVisibleCount(): number;
+
+  /** Current filter state (UI shape). */
+  getFilterState(): FilterState;
+  /** Apply a new filter state: map to engine configs, re-run, persist. */
+  applyFilterState(state: FilterState): void;
+
+  /** Current sort id + direction. */
+  getSort(): { id: string | null; direction: "asc" | "desc" };
+  /** Set the active sort and re-run. */
+  setSort(id: string | null, direction: "asc" | "desc"): void;
+
+  loadSavedSearches(): Promise<SavedSearchItem[]>;
+  addSavedSearch(name: string): Promise<SavedSearchItem[]>;
+  deleteSavedSearch(id: string): Promise<SavedSearchItem[]>;
+  togglePinSavedSearch(id: string): Promise<SavedSearchItem[]>;
+  runSavedSearch(item: SavedSearchItem): void;
+  exportSavedSearches(): Promise<string>;
+  importSavedSearches(json: string): Promise<SavedSearchItem[]>;
+
+  loadSettings(): Promise<SettingsState>;
+  saveSettings(settings: SettingsState): Promise<void>;
+
+  loadHistory(): Promise<HistoryEntry[]>;
+
+  getComparison(): ComparisonResult | null;
+  getComparisonTitles(): Record<string, string>;
+  clearComparison(): void;
+
+  /** Subscribe to a pipeline event; returns an unsubscribe function. */
+  subscribe(event: string, handler: () => void): () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Derivations
+// ---------------------------------------------------------------------------
+
+const TIER_ORDER: PriceRatingTier[] = [
+  "steal",
+  "great-deal",
+  "good-price",
+  "fair-price",
+  "above-market",
+  "high",
+  "overpriced",
+];
+
+function emptyDistribution(): RatingDistribution {
+  return TIER_ORDER.reduce((acc, t) => {
+    acc[t] = 0;
+    return acc;
+  }, {} as RatingDistribution);
+}
+
+function computePriceStats(listings: AnalyzedListing[]): PriceStats {
+  const prices = listings
+    .map((l) => l.price)
+    .filter((p): p is number => p !== null && p > 0)
+    .sort((a, b) => a - b);
+  if (prices.length === 0) return { count: 0, min: 0, max: 0, mean: 0, median: 0 };
+  const sum = prices.reduce((a, b) => a + b, 0);
+  const mid = Math.floor(prices.length / 2);
+  const median =
+    prices.length % 2 === 0 ? (prices[mid - 1] + prices[mid]) / 2 : prices[mid];
+  return {
+    count: prices.length,
+    min: prices[0],
+    max: prices[prices.length - 1],
+    mean: Math.round(sum / prices.length),
+    median: Math.round(median),
+  };
+}
+
+function computeDistribution(listings: AnalyzedListing[]): RatingDistribution {
+  const dist = emptyDistribution();
+  for (const l of listings) {
+    if (l.priceRating && l.priceRating in dist) {
+      dist[l.priceRating as PriceRatingTier]++;
+    }
+  }
+  return dist;
+}
+
+function priceConfidence(count: number): "high" | "medium" | "low" | "insufficient" {
+  if (count >= 20) return "high";
+  if (count >= 10) return "medium";
+  if (count >= 5) return "low";
+  return "insufficient";
+}
+
+function heatTierFromScore(score: number): HeatTier {
+  if (score >= 80) return "fire";
+  if (score >= 60) return "hot";
+  if (score >= 30) return "warm";
+  return "cool";
+}
+
+function forecastUrgency(days: number): "act-fast" | "moderate" | "take-your-time" {
+  if (days <= 2) return "act-fast";
+  if (days <= 7) return "moderate";
+  return "take-your-time";
+}
+
+function firstImage(listing: AnalyzedListing): string | null {
+  return listing.imageUrls.length > 0 ? listing.imageUrls[0] : null;
+}
+
+// ---------------------------------------------------------------------------
+// Context value + provider
+// ---------------------------------------------------------------------------
+
+/** Everything the panels read and the actions they invoke. */
+export interface SidebarData {
+  listings: AnalyzedListing[];
+  visibleCount: number;
+
+  priceStats: PriceStats;
+  ratingDistribution: RatingDistribution;
+  priceConfidence: "high" | "medium" | "low" | "insufficient";
+
+  trustList: TrustDisplayData[];
+  flaggedImages: FlaggedImage[];
+  heatEntries: HeatEntry[];
+  forecastEntries: ForecastEntry[];
+  historyEntries: HistoryEntry[];
+
+  filterState: FilterState;
+  setFilterState: (state: FilterState) => void;
+
+  sort: { id: string | null; direction: "asc" | "desc" };
+  setSort: (id: string | null, direction: "asc" | "desc") => void;
+
+  savedSearches: SavedSearchItem[];
+  addSavedSearch: (name: string) => void;
+  deleteSavedSearch: (id: string) => void;
+  togglePinSavedSearch: (id: string) => void;
+  runSavedSearch: (item: SavedSearchItem) => void;
+  exportSavedSearches: () => Promise<string>;
+  importSavedSearches: (json: string) => void;
+
+  settings: SettingsState;
+  saveSettings: (settings: SettingsState) => void;
+
+  comparison: ComparisonResult | null;
+  comparisonTitles: Record<string, string>;
+  clearComparison: () => void;
+}
+
+const SidebarContext = createContext<SidebarData | null>(null);
+
+/** Access the live sidebar data. Must be used within {@link SidebarDataProvider}. */
+export function useSidebarData(): SidebarData {
+  const ctx = useContext(SidebarContext);
+  if (!ctx) {
+    throw new Error("useSidebarData must be used within a SidebarDataProvider");
+  }
+  return ctx;
+}
+
+/** Props for {@link SidebarDataProvider}. */
+export interface SidebarDataProviderProps {
+  controller: SidebarController;
+  children: ReactNode;
+}
+
+/**
+ * Provider that wires the panels to the live pipeline through the supplied
+ * {@link SidebarController}.
+ */
+export const SidebarDataProvider: React.FC<SidebarDataProviderProps> = ({
+  controller,
+  children,
+}) => {
+  const [listings, setListings] = useState<AnalyzedListing[]>(() =>
+    controller.getAnalyzedListings(),
+  );
+  const [visibleCount, setVisibleCount] = useState(() => controller.getVisibleCount());
+  const [filterState, setFilterStateLocal] = useState<FilterState>(() =>
+    controller.getFilterState(),
+  );
+  const [sort, setSortLocal] = useState(() => controller.getSort());
+  const [savedSearches, setSavedSearches] = useState<SavedSearchItem[]>([]);
+  const [settings, setSettings] = useState<SettingsState>(DEFAULT_SETTINGS);
+  const [historyEntries, setHistoryEntries] = useState<HistoryEntry[]>([]);
+  const [comparison, setComparison] = useState<ComparisonResult | null>(() =>
+    controller.getComparison(),
+  );
+  const [comparisonTitles, setComparisonTitles] = useState<Record<string, string>>(() =>
+    controller.getComparisonTitles(),
+  );
+
+  // Refresh live listings when the pipeline reports analysis or filtering.
+  useEffect(() => {
+    const refresh = (): void => {
+      setListings(controller.getAnalyzedListings());
+      setVisibleCount(controller.getVisibleCount());
+    };
+    const offAnalysis = controller.subscribe(MPS_EVENTS.ANALYSIS_COMPLETE, refresh);
+    const offFiltered = controller.subscribe(MPS_EVENTS.LISTINGS_FILTERED, refresh);
+    const offComparison = controller.subscribe(MPS_EVENTS.COMPARISON_ADDED, () => {
+      setComparison(controller.getComparison());
+      setComparisonTitles(controller.getComparisonTitles());
+    });
+    const offComparisonRemoved = controller.subscribe(MPS_EVENTS.COMPARISON_REMOVED, () => {
+      setComparison(controller.getComparison());
+      setComparisonTitles(controller.getComparisonTitles());
+    });
+    refresh();
+    return () => {
+      offAnalysis();
+      offFiltered();
+      offComparison();
+      offComparisonRemoved();
+    };
+  }, [controller]);
+
+  // Load async data once.
+  useEffect(() => {
+    let active = true;
+    controller.loadSavedSearches().then((s) => active && setSavedSearches(s));
+    controller.loadSettings().then((s) => active && setSettings(s));
+    controller.loadHistory().then((h) => active && setHistoryEntries(h));
+    return () => {
+      active = false;
+    };
+  }, [controller]);
+
+  // --- Derived view-models ---
+  const priceStats = useMemo(() => computePriceStats(listings), [listings]);
+  const ratingDistribution = useMemo(() => computeDistribution(listings), [listings]);
+  const ratedCount = useMemo(
+    () => listings.filter((l) => l.priceRating).length,
+    [listings],
+  );
+
+  const trustList = useMemo<TrustDisplayData[]>(
+    () =>
+      listings
+        .filter((l) => l.sellerTrustScore !== undefined)
+        .map((l) => ({
+          sellerName: l.sellerName ?? "Unknown seller",
+          score: l.sellerTrustScore as number,
+          tier:
+            (l.sellerTrustScore as number) >= 80
+              ? "trusted"
+              : (l.sellerTrustScore as number) >= 60
+                ? "moderate"
+                : (l.sellerTrustScore as number) >= 40
+                  ? "caution"
+                  : "low",
+          confidence: "low",
+          breakdown: {
+            accountAge: 0,
+            rating: 0,
+            ratingVolume: 0,
+            profileCompleteness: 0,
+            response: 0,
+            listingBehavior: 0,
+          },
+          factorsWithData: [],
+        })),
+    [listings],
+  );
+
+  const flaggedImages = useMemo<FlaggedImage[]>(
+    () =>
+      listings
+        .filter((l) => l.aiImageScore !== undefined || (l.imageFlags?.length ?? 0) > 0)
+        .map((l) => ({
+          listingId: l.id,
+          listingTitle: l.title,
+          imageUrl: firstImage(l) ?? "",
+          classification:
+            (l.aiImageScore ?? 0) > 60
+              ? "Likely AI"
+              : (l.aiImageScore ?? 0) > 30
+                ? "Possibly AI"
+                : "Appears Real",
+          aiScore: l.aiImageScore ?? 0,
+          confidence: "low",
+          signalCount: l.imageFlags?.length ?? 0,
+        })),
+    [listings],
+  );
+
+  const heatEntries = useMemo<HeatEntry[]>(
+    () =>
+      listings
+        .filter((l) => l.heatScore !== undefined)
+        .map((l) => ({
+          listingId: l.id,
+          title: l.title,
+          price: l.price,
+          imageUrl: firstImage(l),
+          score: l.heatScore as number,
+          tier: heatTierFromScore(l.heatScore as number),
+          saves: l.engagement.saves,
+          comments: l.engagement.comments,
+          views: l.engagement.views,
+        }))
+        .sort((a, b) => b.score - a.score),
+    [listings],
+  );
+
+  const forecastEntries = useMemo<ForecastEntry[]>(
+    () =>
+      listings
+        .filter((l) => l.estimatedDaysToSell !== undefined)
+        .map((l) => {
+          const days = l.estimatedDaysToSell as number;
+          return {
+            listingId: l.id,
+            title: l.title,
+            price: l.price,
+            displayEstimate: days < 1 ? "Under a day" : `~${Math.round(days)} days`,
+            urgency: forecastUrgency(days),
+            confidence: "low" as const,
+            estimatedDays: days,
+          };
+        })
+        .sort((a, b) => a.estimatedDays - b.estimatedDays),
+    [listings],
+  );
+
+  // --- Actions ---
+  const setFilterState = useCallback(
+    (state: FilterState) => {
+      setFilterStateLocal(state);
+      controller.applyFilterState(state);
+    },
+    [controller],
+  );
+
+  const setSort = useCallback(
+    (id: string | null, direction: "asc" | "desc") => {
+      setSortLocal({ id, direction });
+      controller.setSort(id, direction);
+    },
+    [controller],
+  );
+
+  const addSavedSearch = useCallback(
+    (name: string) => {
+      controller.addSavedSearch(name).then(setSavedSearches);
+    },
+    [controller],
+  );
+  const deleteSavedSearch = useCallback(
+    (id: string) => {
+      controller.deleteSavedSearch(id).then(setSavedSearches);
+    },
+    [controller],
+  );
+  const togglePinSavedSearch = useCallback(
+    (id: string) => {
+      controller.togglePinSavedSearch(id).then(setSavedSearches);
+    },
+    [controller],
+  );
+  const runSavedSearch = useCallback(
+    (item: SavedSearchItem) => controller.runSavedSearch(item),
+    [controller],
+  );
+  const exportSavedSearches = useCallback(
+    () => controller.exportSavedSearches(),
+    [controller],
+  );
+  const importSavedSearches = useCallback(
+    (json: string) => {
+      controller.importSavedSearches(json).then(setSavedSearches);
+    },
+    [controller],
+  );
+  const saveSettings = useCallback(
+    (next: SettingsState) => {
+      setSettings(next);
+      controller.saveSettings(next);
+    },
+    [controller],
+  );
+  const clearComparison = useCallback(() => {
+    controller.clearComparison();
+    setComparison(controller.getComparison());
+    setComparisonTitles(controller.getComparisonTitles());
+  }, [controller]);
+
+  const value: SidebarData = {
+    listings,
+    visibleCount,
+    priceStats,
+    ratingDistribution,
+    priceConfidence: priceConfidence(ratedCount),
+    trustList,
+    flaggedImages,
+    heatEntries,
+    forecastEntries,
+    historyEntries,
+    filterState,
+    setFilterState,
+    sort,
+    setSort,
+    savedSearches,
+    addSavedSearch,
+    deleteSavedSearch,
+    togglePinSavedSearch,
+    runSavedSearch,
+    exportSavedSearches,
+    importSavedSearches,
+    settings,
+    saveSettings,
+    comparison,
+    comparisonTitles,
+    clearComparison,
+  };
+
+  return <SidebarContext.Provider value={value}>{children}</SidebarContext.Provider>;
+};


### PR DESCRIPTION
## Summary

This branch started as a build audit and turned into connecting the large, well-tested-but-**orphaned** core (analysis modules, IndexedDB layer, React sidebar, workers) into the extension that actually runs on the page. Previously the algorithm layer was excellent in isolation but almost none of it was imported by the content script — the build compiled and 540 tests passed, so the gap was invisible to CI and only surfaced via end-to-end tracing.

Everything below keeps **typecheck + lint + build green; 572 tests pass**.

## What changed

**Core wiring**
- **Persistence** (`content/persistence.ts`): the IndexedDB layer is now used at runtime — listings, comparable price corpus, engagement snapshots, sellers, image hashes — plus `chrome.storage` mirrors for the alert worker. Retention settings are enforced on startup.
- **Analysis pipeline** (`content/analysis-runner.ts`): price-rating / heat / forecast now run on live listings; the three previously-unreachable filters (seller-trust, price-rating, image-flag) are registered.
- **Badges** (`content/badge-builder.ts`): price/trust/heat/forecast/image badges render on listing cards.
- **Notifications**: the background worker is now fed real recent-listings + price-drop data; fixed the click-URL map (read but never written) and added dedup — price-drop alerts fire end to end.
- **React sidebar**: mounted into the injected host; all 11 panels rewired from mock `useState` to a live `sidebar-context` fed by the event bus. Filters/Sort drive the real engines; Saved Searches & Settings persist; History reads IndexedDB.

**Overcoming the data-availability limits**
- **Search box** restored in the React `FilterPanel`.
- **Compare** is live: per-card "+ Compare" buttons + selection set feed `compareListings()`; the Compare panel populates with the breakdown + markdown/text export.
- **Trust & Heat**: a new `content/detail-page-parser.ts` scrapes seller profile + engagement on listing **detail pages** (where the data actually exists), scores via the trust engine, and caches it — so grid cards from a visited seller light up.
- **Image analysis** works for real: the MV3 service worker fetches `fbcdn` bytes (CORS-bypassed via a new host permission), decodes with `createImageBitmap`, and reads pixels from an `OffscreenCanvas` without tainting. Gated behind `Settings.autoScanImages`. EXIF is detected for real and excluded from the Facebook-context score via a new renormalizing `excludeSignals` option (FB strips EXIF universally), restoring the full 0–100 range.

**Correctness cleanups**
- Replaced a string-into-number cast in seller trust with a proper `SellerProfile.responseDescription` field.
- Manifests: added missing `commands` (Firefox), `alarms`/`notifications` (Edge), and `*.fbcdn.net` host permission (all three). README sort-option count corrected (8, not 10).

## Verification
`pnpm build`, load `dist/` unpacked on Facebook Marketplace:
- Search box navigates; selecting 2–4 cards populates the Compare panel; opening a listing then returning to the grid shows that seller's Trust badge; enabling image scanning in Settings produces image badges (DevTools shows `fbcdn` fetches from the service worker and a populated `imageHashes` store).

New unit tests cover the persistence mappers, analysis runner, badge builder, detail-page parser, EXIF renormalization, and response-from-description scoring.

https://claude.ai/code/session_01AdhVEaVxYJMWA17jNsx2HU

---
_Generated by [Claude Code](https://claude.ai/code/session_01AdhVEaVxYJMWA17jNsx2HU)_