### PR TITLE
CLA storage fix + wire ComparisonBar, plugin system, and data-processing worker

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -22,8 +22,12 @@ jobs:
         with:
           path-to-signatures: 'signatures/version1/cla.json'
           path-to-document: 'https://github.com/takeedateddy/MarketplaceSucks/blob/main/CLA.md'
-          branch: 'main'
-          allowlist: dependabot[bot],github-actions[bot],noreply@anthropic.com
+          # Store signatures on a dedicated branch so the bot doesn't have to
+          # push to the protected `main` (which requires a PR + the `build`
+          # check, and therefore rejected the signature commit).
+          branch: 'cla-signatures'
+          # Repo owner + bots don't need to sign.
+          allowlist: takeedateddy,dependabot[bot],github-actions[bot],noreply@anthropic.com
           custom-notsigned-prcomment: |
             Thank you for your contribution! Before we can merge this PR, you need to sign our [Contributor License Agreement](https://github.com/takeedateddy/MarketplaceSucks/blob/main/CLA.md).
 

--- a/public/manifest.chrome.json
+++ b/public/manifest.chrome.json
@@ -65,5 +65,15 @@
     "32": "assets/icons/icon-32.png",
     "48": "assets/icons/icon-48.png",
     "128": "assets/icons/icon-128.png"
-  }
+  },
+  "web_accessible_resources": [
+    {
+      "resources": [
+        "data-processing.worker.js"
+      ],
+      "matches": [
+        "https://www.facebook.com/*"
+      ]
+    }
+  ]
 }

--- a/public/manifest.edge.json
+++ b/public/manifest.edge.json
@@ -65,5 +65,15 @@
     "32": "assets/icons/icon-32.png",
     "48": "assets/icons/icon-48.png",
     "128": "assets/icons/icon-128.png"
-  }
+  },
+  "web_accessible_resources": [
+    {
+      "resources": [
+        "data-processing.worker.js"
+      ],
+      "matches": [
+        "https://www.facebook.com/*"
+      ]
+    }
+  ]
 }

--- a/public/manifest.firefox.json
+++ b/public/manifest.firefox.json
@@ -70,5 +70,15 @@
     "32": "assets/icons/icon-32.png",
     "48": "assets/icons/icon-48.png",
     "128": "assets/icons/icon-128.png"
-  }
+  },
+  "web_accessible_resources": [
+    {
+      "resources": [
+        "data-processing.worker.js"
+      ],
+      "matches": [
+        "https://www.facebook.com/*"
+      ]
+    }
+  ]
 }

--- a/scripts/build-extension.mjs
+++ b/scripts/build-extension.mjs
@@ -58,7 +58,7 @@ async function main() {
   console.log(`Building MarketplaceSucks for ${browser}...`);
 
   // 1. Content script (IIFE — self-contained, no imports)
-  console.log('\n[1/3] Building content script (IIFE)...');
+  console.log('\n[1/4] Building content script (IIFE)...');
   await build({
     configFile: false,
     resolve: { alias: sharedAlias },
@@ -88,7 +88,7 @@ async function main() {
   });
 
   // 2. Background service worker (IIFE)
-  console.log('\n[2/3] Building background service worker (IIFE)...');
+  console.log('\n[2/4] Building background service worker (IIFE)...');
   await build({
     configFile: false,
     resolve: { alias: sharedAlias },
@@ -106,8 +106,27 @@ async function main() {
     },
   });
 
-  // 3. Popup (ES module — loaded as HTML page)
-  console.log('\n[3/3] Building popup (ES module)...');
+  // 3. Data-processing Web Worker (IIFE — loaded via web_accessible_resources)
+  console.log('\n[3/4] Building data-processing worker (IIFE)...');
+  await build({
+    configFile: false,
+    resolve: { alias: sharedAlias },
+    define: { 'process.env.BROWSER': JSON.stringify(browser) },
+    build: {
+      outDir: resolve(rootDir, 'dist'),
+      emptyOutDir: false,
+      sourcemap: process.env.NODE_ENV === 'development',
+      lib: {
+        entry: resolve(rootDir, 'src/workers/data-processing.worker.ts'),
+        name: 'MPSDataWorker',
+        formats: ['iife'],
+        fileName: () => 'data-processing.worker.js',
+      },
+    },
+  });
+
+  // 4. Popup (ES module — loaded as HTML page)
+  console.log('\n[4/4] Building popup (ES module)...');
   await build({
     configFile: false,
     plugins: [react()],

--- a/src/content/comparison-bar-mount.tsx
+++ b/src/content/comparison-bar-mount.tsx
@@ -1,0 +1,75 @@
+/**
+ * @module content/comparison-bar-mount
+ *
+ * Mounts the (previously orphaned) {@link ComparisonBar} overlay at the bottom
+ * of the page. It reflects the live comparison selection maintained in the
+ * content script: subscribing to COMPARISON_ADDED/REMOVED to re-render, and
+ * routing its actions back through the event bus / controller.
+ */
+
+import React, { useEffect, useState } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { ComparisonBar } from "@/ui/overlays/ComparisonBar";
+import type { Listing } from "@/core/models/listing";
+import { MPS_EVENTS } from "@/core/utils/event-bus";
+
+/** Dependencies the bar needs from the content-script composition root. */
+export interface ComparisonBarDeps {
+  /** Listings currently selected for comparison (in selection order). */
+  getSelectedListings: () => Listing[];
+  /** Subscribe to a pipeline event; returns an unsubscribe function. */
+  subscribe: (event: string, handler: () => void) => () => void;
+  /** Remove one listing from the comparison selection. */
+  onRemove: (id: string) => void;
+  /** Clear the whole selection. */
+  onClear: () => void;
+  /** Open the full comparison view (the sidebar Compare panel). */
+  onCompare: () => void;
+}
+
+const ComparisonBarContainer: React.FC<{ deps: ComparisonBarDeps }> = ({ deps }) => {
+  const [listings, setListings] = useState<Listing[]>(() => deps.getSelectedListings());
+
+  useEffect(() => {
+    const refresh = (): void => setListings(deps.getSelectedListings());
+    const offAdded = deps.subscribe(MPS_EVENTS.COMPARISON_ADDED, refresh);
+    const offRemoved = deps.subscribe(MPS_EVENTS.COMPARISON_REMOVED, refresh);
+    refresh();
+    return () => {
+      offAdded();
+      offRemoved();
+    };
+  }, [deps]);
+
+  return (
+    <ComparisonBar
+      listings={listings}
+      onRemove={deps.onRemove}
+      onClear={deps.onClear}
+      onCompare={deps.onCompare}
+    />
+  );
+};
+
+/** Handle returned by {@link mountComparisonBar} for teardown. */
+export interface ComparisonBarHandle {
+  unmount: () => void;
+}
+
+/** Render the comparison bar into a dedicated root appended to the page body. */
+export function mountComparisonBar(deps: ComparisonBarDeps): ComparisonBarHandle {
+  const host = document.createElement("div");
+  host.id = "mps-comparison-bar-root";
+  host.setAttribute("data-mps-component", "comparison-bar");
+  document.body.appendChild(host);
+
+  const root: Root = createRoot(host);
+  root.render(<ComparisonBarContainer deps={deps} />);
+
+  return {
+    unmount: () => {
+      root.unmount();
+      host.remove();
+    },
+  };
+}

--- a/src/content/data-worker-client.ts
+++ b/src/content/data-worker-client.ts
@@ -1,0 +1,68 @@
+/**
+ * @module content/data-worker-client
+ *
+ * Thin client for the data-processing Web Worker. Lazily spawns the worker
+ * (built to `dist/data-processing.worker.js` and exposed via
+ * `web_accessible_resources`), correlates responses by id, and exposes a typed
+ * `aggregatePrices` call. Best-effort: if the worker can't be created it falls
+ * back to computing inline so callers never break.
+ */
+
+import { browser } from "@/platform/browser";
+import { aggregatePrices as aggregateInline, type PriceAggregate } from "@/core/utils/price-aggregate";
+
+const WORKER_PATH = "data-processing.worker.js";
+
+interface PendingRequest {
+  resolve: (value: PriceAggregate) => void;
+  reject: (reason?: unknown) => void;
+}
+
+/** Client around the data-processing worker with a graceful inline fallback. */
+export class DataWorkerClient {
+  private worker: Worker | null = null;
+  private seq = 0;
+  private readonly pending = new Map<string, PendingRequest>();
+
+  private ensureWorker(): Worker | null {
+    if (this.worker) return this.worker;
+    try {
+      const url = browser.runtime.getURL(WORKER_PATH);
+      this.worker = new Worker(url);
+      this.worker.onmessage = (event: MessageEvent<{ id: string; result?: PriceAggregate; error?: string }>) => {
+        const { id, result, error } = event.data;
+        const req = this.pending.get(id);
+        if (!req) return;
+        this.pending.delete(id);
+        if (error || !result) req.reject(new Error(error ?? "worker error"));
+        else req.resolve(result);
+      };
+      this.worker.onerror = () => {
+        // Drop the worker; subsequent calls fall back to inline computation.
+        this.worker = null;
+      };
+    } catch {
+      this.worker = null;
+    }
+    return this.worker;
+  }
+
+  /** Aggregate prices off the main thread, falling back to inline on failure. */
+  aggregatePrices(prices: number[]): Promise<PriceAggregate> {
+    const worker = this.ensureWorker();
+    if (!worker) return Promise.resolve(aggregateInline(prices));
+
+    const id = `agg-${++this.seq}`;
+    return new Promise<PriceAggregate>((resolve, reject) => {
+      this.pending.set(id, { resolve, reject });
+      worker.postMessage({ type: "aggregate-prices", id, payload: { prices } });
+    }).catch(() => aggregateInline(prices));
+  }
+
+  /** Terminate the worker and reject any in-flight requests. */
+  terminate(): void {
+    this.worker?.terminate();
+    this.worker = null;
+    this.pending.clear();
+  }
+}

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -72,6 +72,7 @@ import type { PluginContext } from "@/plugins/plugin.interface";
 import { createBuiltinPlugins } from "@/plugins/builtin";
 import { ChromeStorageAdapter } from "@/platform/chrome-storage-adapter";
 import type { ISorter } from "@/core/interfaces/sorter.interface";
+import { DataWorkerClient } from "@/content/data-worker-client";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -251,6 +252,10 @@ async function bootstrap(): Promise<void> {
       void pluginManager.teardownAll();
     });
 
+    // Data-processing worker: offloads price aggregation from the main thread.
+    const dataWorker = new DataWorkerClient();
+    cleanupFns.push(() => dataWorker.terminate());
+
     // Enforce data-retention settings so IndexedDB stays bounded.
     storageGet<{ historyRetentionDays?: number; priceDataRetentionDays?: number }>(
       "mps:settings",
@@ -389,6 +394,14 @@ async function bootstrap(): Promise<void> {
           });
           // Fire-and-forget image analysis (no-op unless enabled in settings).
           void maybeScanImages(analyzed);
+          // Offload price-stats aggregation to the worker and persist for the popup.
+          const prices = Array.from(knownListings.values())
+            .map((l) => l.price)
+            .filter((p): p is number => p !== null && p > 0);
+          dataWorker
+            .aggregatePrices(prices)
+            .then((stats) => storageSet("mps-price-stats", stats))
+            .catch(() => {});
         } catch (err) {
           console.warn(`${LOG_PREFIX} Analysis/persistence error:`, err);
         }

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -73,6 +73,7 @@ import { createBuiltinPlugins } from "@/plugins/builtin";
 import { ChromeStorageAdapter } from "@/platform/chrome-storage-adapter";
 import type { ISorter } from "@/core/interfaces/sorter.interface";
 import { DataWorkerClient } from "@/content/data-worker-client";
+import { mountComparisonBar } from "@/content/comparison-bar-mount";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -506,6 +507,23 @@ async function bootstrap(): Promise<void> {
     });
     const sidebarMount = mountSidebar(sidebarController);
     if (sidebarMount) cleanupFns.push(() => sidebarMount.unmount());
+
+    // Mount the bottom comparison bar, reflecting the live selection.
+    const comparisonBar = mountComparisonBar({
+      getSelectedListings: () =>
+        Array.from(comparisonSelection)
+          .map((id) => knownListings.get(id))
+          .filter((l): l is AnalyzedListing => l !== undefined),
+      subscribe: (event, handler) => eventBus.on(event, handler),
+      onRemove: (id) => eventBus.emit(MPS_EVENTS.COMPARISON_REMOVED, { listingId: id }),
+      onClear: () => {
+        for (const id of Array.from(comparisonSelection)) {
+          eventBus.emit(MPS_EVENTS.COMPARISON_REMOVED, { listingId: id });
+        }
+      },
+      onCompare: () => eventBus.emit(MPS_EVENTS.SIDEBAR_TOGGLED, { open: true }),
+    });
+    cleanupFns.push(() => comparisonBar.unmount());
 
     // 6. Load persisted settings (may emit SIDEBAR_TOGGLED to reopen sidebar)
     await loadSettings(eventBus);

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -67,6 +67,11 @@ import {
   buildSellerRecord,
 } from "@/content/detail-page-parser";
 import type { ImageAnalysisResult } from "@/background/image-analysis";
+import { PluginManager } from "@/plugins/plugin-manager";
+import type { PluginContext } from "@/plugins/plugin.interface";
+import { createBuiltinPlugins } from "@/plugins/builtin";
+import { ChromeStorageAdapter } from "@/platform/chrome-storage-adapter";
+import type { ISorter } from "@/core/interfaces/sorter.interface";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -227,6 +232,23 @@ async function bootstrap(): Promise<void> {
       } catch (err) {
         console.warn(`${LOG_PREFIX} Detail-page parse failed:`, err);
       }
+    });
+
+    // Plugin system: register bundled plugins with a context that exposes the
+    // event bus, storage, and the filter/sorter registries so plugins can
+    // extend the pipeline.
+    const pluginManager = new PluginManager();
+    const pluginContext: PluginContext = {
+      events: eventBus,
+      storage: new ChromeStorageAdapter(),
+      registerFilter: (filter) => filterRegistry.register(filter as IFilter),
+      registerSorter: (sorter) => sortRegistry.register(sorter as ISorter),
+    };
+    for (const plugin of createBuiltinPlugins()) {
+      await pluginManager.register(plugin, pluginContext);
+    }
+    cleanupFns.push(() => {
+      void pluginManager.teardownAll();
     });
 
     // Enforce data-retention settings so IndexedDB stays bounded.

--- a/src/core/utils/price-aggregate.test.ts
+++ b/src/core/utils/price-aggregate.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { aggregatePrices } from "@/core/utils/price-aggregate";
+
+describe("aggregatePrices", () => {
+  it("returns a zeroed aggregate for an empty list", () => {
+    expect(aggregatePrices([])).toEqual({
+      count: 0,
+      min: 0,
+      max: 0,
+      mean: 0,
+      median: 0,
+      stdDev: 0,
+      p25: 0,
+      p75: 0,
+    });
+  });
+
+  it("ignores non-positive and non-finite prices", () => {
+    const result = aggregatePrices([100, 0, -50, NaN, Infinity, 200]);
+    expect(result.count).toBe(2);
+    expect(result.min).toBe(100);
+    expect(result.max).toBe(200);
+  });
+
+  it("computes summary statistics", () => {
+    const result = aggregatePrices([100, 110, 120, 130, 140]);
+    expect(result.count).toBe(5);
+    expect(result.min).toBe(100);
+    expect(result.max).toBe(140);
+    expect(result.mean).toBe(120);
+    expect(result.median).toBe(120);
+    expect(result.p25).toBeLessThanOrEqual(result.median);
+    expect(result.p75).toBeGreaterThanOrEqual(result.median);
+  });
+});

--- a/src/core/utils/price-aggregate.ts
+++ b/src/core/utils/price-aggregate.ts
@@ -1,0 +1,56 @@
+/**
+ * @module core/utils/price-aggregate
+ *
+ * Pure price-distribution aggregation, shared by the data-processing Web Worker
+ * (which offloads it from the main thread) and unit tests. Reuses the existing
+ * statistics helpers in {@link module:core/utils/math-utils}.
+ */
+
+import { median, mean, standardDeviation, percentile } from "@/core/utils/math-utils";
+
+/** Summary statistics over a set of prices. */
+export interface PriceAggregate {
+  count: number;
+  min: number;
+  max: number;
+  mean: number;
+  median: number;
+  stdDev: number;
+  /** 25th percentile. */
+  p25: number;
+  /** 75th percentile. */
+  p75: number;
+}
+
+/** Empty aggregate (no usable prices). */
+const EMPTY: PriceAggregate = {
+  count: 0,
+  min: 0,
+  max: 0,
+  mean: 0,
+  median: 0,
+  stdDev: 0,
+  p25: 0,
+  p75: 0,
+};
+
+/**
+ * Aggregate a list of prices into summary statistics. Non-positive and
+ * non-finite values are ignored. Returns a zeroed aggregate when no usable
+ * prices remain.
+ */
+export function aggregatePrices(prices: readonly number[]): PriceAggregate {
+  const valid = prices.filter((p) => Number.isFinite(p) && p > 0);
+  if (valid.length === 0) return { ...EMPTY };
+  const sorted = [...valid].sort((a, b) => a - b);
+  return {
+    count: sorted.length,
+    min: sorted[0],
+    max: sorted[sorted.length - 1],
+    mean: Math.round(mean(sorted)),
+    median: Math.round(median(sorted)),
+    stdDev: Math.round(standardDeviation(sorted)),
+    p25: Math.round(percentile(sorted, 25)),
+    p75: Math.round(percentile(sorted, 75)),
+  };
+}

--- a/src/platform/chrome-storage-adapter.ts
+++ b/src/platform/chrome-storage-adapter.ts
@@ -1,0 +1,58 @@
+/**
+ * @module platform/chrome-storage-adapter
+ *
+ * {@link IStorageAdapter} implementation backed by the extension's storage
+ * (via the `@/platform/storage` helpers). This is the concrete adapter handed
+ * to plugins through their {@link PluginContext} so they can persist data
+ * without depending on a specific storage mechanism.
+ */
+
+import type { IStorageAdapter, StorageEntry } from "@/core/interfaces/storage.interface";
+import {
+  storageGet,
+  storageGetMany,
+  storageSet,
+  storageSetMany,
+  storageRemove,
+  storageClear,
+} from "@/platform/storage";
+
+/** chrome.storage-backed {@link IStorageAdapter}. */
+export class ChromeStorageAdapter implements IStorageAdapter {
+  async get<T>(key: string): Promise<T | null> {
+    return storageGet<T | null>(key, null);
+  }
+
+  async set<T>(key: string, value: T): Promise<void> {
+    await storageSet(key, value);
+  }
+
+  async remove(key: string): Promise<void> {
+    await storageRemove(key);
+  }
+
+  async clear(): Promise<void> {
+    await storageClear();
+  }
+
+  async getMany<T>(keys: readonly string[]): Promise<Map<string, T>> {
+    const defaults = Object.fromEntries(keys.map((k) => [k, null]));
+    const result = await storageGetMany(defaults);
+    const map = new Map<string, T>();
+    for (const key of keys) {
+      const value = result[key];
+      if (value !== null && value !== undefined) {
+        map.set(key, value as T);
+      }
+    }
+    return map;
+  }
+
+  async setMany<T>(entries: readonly StorageEntry<T>[]): Promise<void> {
+    const items: Record<string, unknown> = {};
+    for (const { key, value } of entries) {
+      items[key] = value;
+    }
+    await storageSetMany(items);
+  }
+}

--- a/src/plugins/builtin.ts
+++ b/src/plugins/builtin.ts
@@ -1,0 +1,16 @@
+/**
+ * @module plugins/builtin
+ *
+ * The set of plugins bundled with the extension and registered at startup by
+ * the content script. Add bundled plugins here; third-party plugins would be
+ * added to this list and rebuilt (content scripts run in an isolated world, so
+ * runtime injection from the page is not supported).
+ */
+
+import type { IPlugin } from "@/plugins/plugin.interface";
+import { ListingCounterPlugin } from "@/plugins/examples/listing-counter.plugin";
+
+/** Factory so each bootstrap gets fresh plugin instances. */
+export function createBuiltinPlugins(): IPlugin[] {
+  return [new ListingCounterPlugin()];
+}

--- a/src/plugins/examples/listing-counter.plugin.ts
+++ b/src/plugins/examples/listing-counter.plugin.ts
@@ -1,0 +1,41 @@
+/**
+ * @module plugins/examples/listing-counter
+ *
+ * A minimal reference {@link IPlugin} that demonstrates the plugin lifecycle and
+ * the {@link PluginContext}: it subscribes to analysis-complete events and keeps
+ * a running count of analyzed listings in storage. Useful as a copy-paste
+ * starting point for real plugins (which can also `registerFilter` /
+ * `registerSorter`).
+ */
+
+import type { IPlugin, PluginContext } from "@/plugins/plugin.interface";
+import { MPS_EVENTS } from "@/core/utils/event-bus";
+
+/** Storage key the example plugin writes its tally to. */
+export const LISTING_COUNTER_KEY = "mps-plugin:listing-counter";
+
+export class ListingCounterPlugin implements IPlugin {
+  readonly id = "listing-counter";
+  readonly name = "Listing Counter (example)";
+  readonly version = "1.0.0";
+  readonly author = "MarketplaceSucks";
+
+  private unsubscribe: (() => void) | null = null;
+
+  async initialize(context: PluginContext): Promise<void> {
+    this.unsubscribe = context.events.on<{ total: number }>(
+      MPS_EVENTS.ANALYSIS_COMPLETE,
+      ({ total }) => {
+        void context.storage.set(LISTING_COUNTER_KEY, {
+          total,
+          updatedAt: Date.now(),
+        });
+      },
+    );
+  }
+
+  async teardown(): Promise<void> {
+    this.unsubscribe?.();
+    this.unsubscribe = null;
+  }
+}

--- a/src/plugins/plugin-manager.test.ts
+++ b/src/plugins/plugin-manager.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi } from "vitest";
+import { PluginManager } from "@/plugins/plugin-manager";
+import type { IPlugin, PluginContext } from "@/plugins/plugin.interface";
+
+const ctx = {} as PluginContext;
+
+function makePlugin(id: string, overrides: Partial<IPlugin> = {}): IPlugin {
+  return {
+    id,
+    name: `Plugin ${id}`,
+    version: "1.0.0",
+    author: "test",
+    initialize: vi.fn().mockResolvedValue(undefined),
+    teardown: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+describe("PluginManager", () => {
+  it("registers and initializes a plugin", async () => {
+    const manager = new PluginManager();
+    const plugin = makePlugin("a");
+    await manager.register(plugin, ctx);
+    expect(plugin.initialize).toHaveBeenCalledWith(ctx);
+    expect(manager.get("a")).toBe(plugin);
+    expect(manager.getAll()).toHaveLength(1);
+  });
+
+  it("replaces (and tears down) a duplicate id on re-register", async () => {
+    const manager = new PluginManager();
+    const first = makePlugin("dup");
+    const second = makePlugin("dup");
+    await manager.register(first, ctx);
+    await manager.register(second, ctx);
+    expect(first.teardown).toHaveBeenCalled();
+    expect(manager.get("dup")).toBe(second);
+    expect(manager.getAll()).toHaveLength(1);
+  });
+
+  it("does not retain a plugin whose initialize throws", async () => {
+    const manager = new PluginManager();
+    const bad = makePlugin("bad", {
+      initialize: vi.fn().mockRejectedValue(new Error("boom")),
+    });
+    await manager.register(bad, ctx);
+    expect(manager.get("bad")).toBeUndefined();
+  });
+
+  it("unregisters and tears down", async () => {
+    const manager = new PluginManager();
+    const plugin = makePlugin("a");
+    await manager.register(plugin, ctx);
+    await manager.unregister("a");
+    expect(plugin.teardown).toHaveBeenCalled();
+    expect(manager.get("a")).toBeUndefined();
+  });
+
+  it("tears down all plugins", async () => {
+    const manager = new PluginManager();
+    const a = makePlugin("a");
+    const b = makePlugin("b");
+    await manager.register(a, ctx);
+    await manager.register(b, ctx);
+    await manager.teardownAll();
+    expect(a.teardown).toHaveBeenCalled();
+    expect(b.teardown).toHaveBeenCalled();
+    expect(manager.getAll()).toHaveLength(0);
+  });
+});

--- a/src/ui/popup/Popup.tsx
+++ b/src/ui/popup/Popup.tsx
@@ -11,6 +11,7 @@ import { browser } from '@/platform/browser';
 interface PopupStats {
   listingCount: number;
   filterCount: number;
+  medianPrice: number;
 }
 
 /**
@@ -20,6 +21,7 @@ export function Popup() {
   const [stats, setStats] = useState<PopupStats>({
     listingCount: 0,
     filterCount: 0,
+    medianPrice: 0,
   });
   const [isOnMarketplace, setIsOnMarketplace] = useState(false);
 
@@ -30,15 +32,18 @@ export function Popup() {
       setIsOnMarketplace(url.includes('facebook.com/marketplace'));
     });
 
-    // Get stats from background
-    browser.runtime.sendMessage({ action: 'get-stats' }).then((response: unknown) => {
+    // Get stats from background + the worker-computed price aggregate.
+    Promise.all([
+      browser.runtime.sendMessage({ action: 'get-stats' }).catch(() => null),
+      browser.storage.local.get('mps-price-stats').catch(() => ({})),
+    ]).then(([response, stored]) => {
       const res = response as Record<string, number> | null;
-      if (res) {
-        setStats({
-          listingCount: res.listingCount ?? 0,
-          filterCount: res.filterCount ?? 0,
-        });
-      }
+      const priceStats = (stored as Record<string, { median?: number }>)['mps-price-stats'];
+      setStats({
+        listingCount: res?.listingCount ?? 0,
+        filterCount: res?.filterCount ?? 0,
+        medianPrice: priceStats?.median ?? 0,
+      });
     });
   }, []);
 
@@ -77,6 +82,12 @@ export function Popup() {
                 <div style={styles.statNumber}>{stats.filterCount}</div>
                 <div style={styles.statLabel}>After filters</div>
               </div>
+              {stats.medianPrice > 0 && (
+                <div style={styles.statCard}>
+                  <div style={styles.statNumber}>${stats.medianPrice}</div>
+                  <div style={styles.statLabel}>Median price</div>
+                </div>
+              )}
             </div>
 
             {/* Actions */}

--- a/src/workers/data-processing.worker.ts
+++ b/src/workers/data-processing.worker.ts
@@ -1,46 +1,39 @@
 /**
- * Web Worker for heavy IndexedDB operations.
- * Handles batch writes, data aggregation, and cleanup
- * without blocking the main thread.
+ * Web Worker for off-main-thread data processing.
+ *
+ * Scope note: a content-script-spawned worker runs in the extension origin, not
+ * the page origin, so it cannot touch the page-origin IndexedDB the extension
+ * persists to — DB writes/cleanup stay on the main thread (see
+ * `content/persistence.ts`). This worker therefore handles *pure* computation
+ * that benefits from being off the main thread: price aggregation over
+ * potentially large listing sets.
  *
  * @module data-processing-worker
  */
 
-/** Message types the worker accepts */
-interface WorkerMessage {
-  type: 'batch-save' | 'aggregate-prices' | 'cleanup-old-data';
+import { aggregatePrices } from "@/core/utils/price-aggregate";
+
+/** Request sent to the worker. */
+interface AggregateRequest {
+  type: "aggregate-prices";
   id: string;
-  payload: unknown;
+  payload: { prices: number[] };
 }
 
-self.onmessage = (event: MessageEvent<WorkerMessage>) => {
-  const { type, id } = event.data;
-
+self.onmessage = (event: MessageEvent<AggregateRequest>) => {
+  const { type, id, payload } = event.data;
   try {
-    switch (type) {
-      case 'batch-save':
-        // Scaffold: batch IndexedDB writes
-        self.postMessage({ type: 'batch-save-result', id, result: { saved: 0 } });
-        break;
-
-      case 'aggregate-prices':
-        // Scaffold: price data aggregation
-        self.postMessage({ type: 'aggregate-result', id, result: {} });
-        break;
-
-      case 'cleanup-old-data':
-        // Scaffold: delete data older than retention period
-        self.postMessage({ type: 'cleanup-result', id, result: { deleted: 0 } });
-        break;
-
-      default:
-        self.postMessage({ type: 'error', id, error: `Unknown type: ${type}` });
+    if (type === "aggregate-prices") {
+      const result = aggregatePrices(payload?.prices ?? []);
+      self.postMessage({ type: "aggregate-result", id, result });
+    } else {
+      self.postMessage({ type: "error", id, error: `Unknown type: ${type}` });
     }
   } catch (err) {
     self.postMessage({
-      type: 'error',
+      type: "error",
       id,
-      error: err instanceof Error ? err.message : 'Unknown error',
+      error: err instanceof Error ? err.message : "Unknown error",
     });
   }
 };


### PR DESCRIPTION
Follow-ups after #50. Keeps **typecheck + lint + build green; 580 tests pass**.

## CLA config fix (`.github/workflows/cla.yml`)
The CLA Assistant wrote signatures to the protected `main` branch, which requires a PR + the `build` check — so the bot's signature commit was rejected (`Repository rule violations found`). Now:
- `branch: 'cla-signatures'` — signatures persist on a dedicated, unprotected branch.
- Added `takeedateddy` to the `allowlist` so the owner (and bots) aren't blocked.

> Note: because `pull_request_target` runs the workflow from the base branch, this takes effect once merged to `main`; it fixes future PRs, not necessarily this one's own CLA check.

## ComparisonBar overlay (was orphaned)
Mounted `ui/overlays/ComparisonBar.tsx` into a dedicated body root, fed by the live comparison selection. Subscribes to `COMPARISON_ADDED/REMOVED` to re-render; remove/clear route through the event bus; "Compare" opens the sidebar Compare panel; self-hides when empty. (`content/comparison-bar-mount.tsx`)

## Plugin system (was never instantiated)
- `ChromeStorageAdapter` implements `IStorageAdapter` over `@/platform/storage` for the plugin context.
- `createBuiltinPlugins()` registry + an example `ListingCounterPlugin` demonstrating the lifecycle/context.
- Content bootstrap builds a `PluginContext` (event bus, storage, `registerFilter`/`registerSorter` → the live registries), registers bundled plugins at startup, and tears them down on cleanup.
- Plugin contexts run in the content script's isolated world, so third-party plugins are added to the bundled list and rebuilt (documented).
- Added `PluginManager` unit tests.

## Data-processing worker (was a stub)
The original `batch-save`/`cleanup-old-data` ops are infeasible from a content-spawned worker (extension origin ≠ page-origin IndexedDB), so DB work stays on the main thread. Repurposed the worker as a **pure off-main-thread compute** worker:
- `core/utils/price-aggregate.ts` (`aggregatePrices`, reusing `math-utils`) + tests.
- Worker implements `aggregate-prices` via it; `content/data-worker-client.ts` is a typed client with id-correlation and an inline fallback if the worker can't spawn.
- 4th IIFE build step emits `data-processing.worker.js`; manifests expose it via `web_accessible_resources`.
- Content offloads price aggregation each analysis pass and persists `mps-price-stats`; the popup now shows median price.

## Verification
`pnpm build`, load `dist/` unpacked on Facebook Marketplace: selecting cards shows the bottom comparison bar (remove/clear/compare); the popup shows a median-price stat once listings are scanned; bundled plugin runs at startup. Unit tests cover the price aggregate, plugin manager, and storage paths.

https://claude.ai/code/session_01AdhVEaVxYJMWA17jNsx2HU

---
_Generated by [Claude Code](https://claude.ai/code/session_01AdhVEaVxYJMWA17jNsx2HU)_