### PR TITLE
Close the re-audit gaps: wire 2 panels, badges, onboarding, seen/heat/originality + doc fixes

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -122,7 +122,7 @@ Analysis engines run in parallel with the filter/sort pipeline. Each analyzer su
 - **Related listings** (`related-listings.ts`) -- finds similar listings
 - **Image fingerprint** (`image-fingerprint.ts`) -- perceptual hashing for duplicate detection
 
-Heavy analyzers (those with `isHeavy: true`) are dispatched to Web Workers (`src/workers/`) to avoid blocking the main thread.
+Heavy work is kept off the page's main thread: price aggregation runs in the data-processing **Web Worker** (`src/workers/data-processing.worker.ts`), and image analysis (fetch + decode + heuristics) runs in the **background service worker** (`src/background/image-analysis.ts`), which can fetch cross-origin Facebook CDN images without canvas tainting. The `isHeavy` analyzer flag remains the hook for routing future heavy analyzers off-thread.
 
 ### 8. Persistence
 

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Detect AI-generated and suspicious listing images using **local heuristics** (no
 - Web Worker pipeline ready for TF.js model loading and inference
 - Combined scoring: 70% ML + 30% heuristic when model is available
 - Falls back to 100% heuristic when model is not loaded
-- All inference runs locally in a Web Worker -- never blocks the UI
+- All inference runs locally in the background service worker (which can fetch + decode images off the page's main thread) -- never blocks the UI
 
 ### Market Intelligence
 
@@ -201,7 +201,7 @@ Background alert system for saved search matches and price drops.
 - **Price drop alerts:** Detects price decreases ≥5% on tracked listings. Notification shows previous price, current price, and drop percentage.
 - **Badge count:** Red badge on extension icon shows unread notification count.
 - **Notification click:** Opens the listing URL in a new tab.
-- **Configurable frequency:** Realtime (5 min), Hourly, Daily, or Manual.
+- **Per-search alert frequency:** choose Realtime, Hourly, Daily, or Manual on each saved search (Manual disables its alerts; the background worker runs its check on a fixed interval).
 - **Notification panel:** Sidebar panel showing notification history with read/unread state, type badges (New Match / Price Drop), and time-ago formatting.
 
 ### Selector Health Monitoring
@@ -225,7 +225,7 @@ Facebook changes their DOM frequently, which can break the extension's CSS selec
   - `Alt+F` -- Focus keyword filter input
   - `Alt+C` -- Clear all active filters
 - **First-time onboarding** -- 3-step walkthrough on first install (toggle button, filters, intelligence features)
-- **All data stored locally** -- IndexedDB stores for listings, sellers, image hashes, price data, engagement snapshots, seen listings, and saved searches
+- **All data stored locally** -- IndexedDB stores for listings, sellers, image hashes, price data, engagement snapshots, and seen listings; saved searches, settings, and notification history live in chrome.storage.local
 - **Dark mode** -- automatic detection of Facebook's dark mode with full theme switching
 
 ---
@@ -761,7 +761,7 @@ Enable notifications on a saved search to receive browser alerts when new matchi
 
 ## Privacy
 
-**MarketplaceSucks collects no data.** There are no analytics, no tracking pixels, no external API calls, and no remote servers. Every computation runs locally in your browser. All persisted data (listing history, saved searches, seen tracking, price history, engagement snapshots) is stored in your browser's IndexedDB and never leaves your machine.
+**MarketplaceSucks collects no data.** There are no analytics, no tracking pixels, no external API calls, and no remote servers. Every computation runs locally in your browser. All persisted data (listing history, price history, engagement snapshots, seen tracking in IndexedDB; saved searches, settings, and notifications in chrome.storage.local) is stored locally in your browser and never leaves your machine.
 
 | What | Where | Shared? |
 |------|-------|---------|
@@ -769,7 +769,7 @@ Enable notifications on a saved search to receive browser alerts when new matchi
 | Listings | IndexedDB | No |
 | Seller profiles | IndexedDB | No |
 | Price history | IndexedDB | No |
-| Saved searches | IndexedDB | No |
+| Saved searches | chrome.storage.local | No |
 | Image hashes | IndexedDB | No |
 | Notifications | `chrome.storage.local` | No |
 
@@ -786,22 +786,24 @@ platform/       Browser abstraction (Chrome, Firefox, Edge APIs)
 core/           Business logic (filters, sorters, analyzers, models, interfaces, utils)
   analysis/     Seller trust, price rating, image detection, heat tracking,
                 sales forecasting, comparison, notifications, selector health, ML detector
-  filters/      10 filter implementations + engine + registry
+  filters/      9 filter implementations + engine + registry
   sorters/      8 sorter implementations + engine + registry
   models/       Listing, Seller, Engagement, PriceData, SavedSearch, AnalyzedListing
   utils/        Math, text, date, similarity, event bus, perf, LRU cache, search I/O, comparison export
 content/        DOM observation, parsing, manipulation, selector config, onboarding
-data/           IndexedDB persistence (6 repositories, schema migrations)
-ui/             React sidebar (12 panels), overlays, popup, preview
+data/           IndexedDB persistence (7 repositories, schema migrations)
+ui/             React sidebar (13 panels), overlays, popup, preview
 design-system/  15 primitives, 9 composites, 3 layouts, theming, tokens
-workers/        Web Workers for image analysis + data processing
+workers/        Web Worker for off-main-thread data processing
+                (image analysis runs in the background service worker, which
+                 can fetch + decode cross-origin images without canvas tainting)
 plugins/        Plugin system for third-party extensions
 ```
 
 **Key design decisions:**
 - All `core/` modules are **pure functions** with zero browser dependencies -- trivially testable
 - Communication via **event bus** (pub/sub) -- no direct imports between layers
-- **Shadow DOM** for UI injection -- no CSS conflicts with Facebook
+- **Scoped, prefixed styles** for the injected sidebar (mounted into the page DOM via React); the onboarding overlay uses Shadow DOM for stronger isolation
 - **Web Workers** for heavy computation (image analysis, data processing)
 - **requestAnimationFrame** batching for DOM manipulation -- no layout thrashing
 - **2-second element cache** in DomManipulator for performance
@@ -812,7 +814,7 @@ For the full architecture documentation, see [ARCHITECTURE.md](ARCHITECTURE.md).
 
 ## Testing
 
-The project has a comprehensive test suite with **540+ tests** across 43 test files.
+The project has a comprehensive test suite with **580+ tests** across 49 test files.
 
 ```bash
 pnpm test              # Run all tests
@@ -824,10 +826,14 @@ pnpm test:coverage     # Run with coverage (80% threshold on src/core/)
 |----------|-------|-------|----------------|
 | Utils | 7 | ~170 | Math, text, date, similarity, event bus, perf, search I/O, comparison export, LRU cache |
 | Models | 5 | 53 | Listing, seller, engagement, price data, saved search factories + validators |
-| Filters | 12 | 99 | All 10 filters + engine pipeline + registry |
+| Filters | 12 | 99 | All 9 filters + engine pipeline + registry |
 | Sorters | 3 | 24 | All 8 sorters + engine + registry |
 | Analyzers | 12 | ~145 | Trust, price, image, fingerprint, heat, forecast, comparison, related, notifications, selector health, ML detector |
-| E2E | 4 | ~50 | Selector validation against HTML fixtures, parser pipeline, dark mode detection |
+| Content | 4 | ~25 | Persistence mappers, analysis runner, badge builder, detail-page parser |
+| Plugins | 1 | 5 | Plugin manager lifecycle |
+| E2E | 3 | ~35 | Selector validation against HTML fixtures, parser pipeline, dark mode detection |
+
+(Counts are approximate; run `pnpm test` for the exact total.)
 
 **CI pipeline** runs lint + typecheck + test + build on every PR.
 

--- a/src/background/image-analysis.ts
+++ b/src/background/image-analysis.ts
@@ -28,6 +28,8 @@ export interface ImageAnalysisResult {
   classification: string;
   /** Names of the triggered heuristic signals. */
   flags: string[];
+  /** Whether a uniform/solid background was detected (used for originality). */
+  hasUniformBackground: boolean;
   width: number;
   height: number;
 }
@@ -135,6 +137,7 @@ export async function analyzeImageUrl(url: string): Promise<ImageAnalysisResult 
     const { data } = ctx.getImageData(0, 0, SAMPLE, SAMPLE);
 
     const { avgSaturation, saturationStdDev } = saturationStats(data);
+    const uniformBackground = hasUniformBackground(data, SAMPLE);
     const hash = computePerceptualHash(toGrayscale32(bitmap));
     bitmap.close();
 
@@ -142,7 +145,7 @@ export async function analyzeImageUrl(url: string): Promise<ImageAnalysisResult 
       width,
       height,
       hasExif,
-      hasUniformBackground: hasUniformBackground(data, SAMPLE),
+      hasUniformBackground: uniformBackground,
       avgSaturation,
       saturationStdDev,
       isCommonAiAspectRatio: isCommonAiAspectRatio(width, height),
@@ -157,6 +160,7 @@ export async function analyzeImageUrl(url: string): Promise<ImageAnalysisResult 
       aiScore: result.aiScore,
       classification: result.classification,
       flags: result.signals.filter((s) => s.triggered).map((s) => s.name),
+      hasUniformBackground: uniformBackground,
       width,
       height,
     };

--- a/src/background/service-worker.ts
+++ b/src/background/service-worker.ts
@@ -170,6 +170,7 @@ async function checkAlerts(): Promise<void> {
     'mps-last-alert-check',
     'mps-notification-badge-count',
     'mps-notification-urls',
+    'mps-notifications',
   ]);
 
   const data = result as Record<string, unknown>;
@@ -198,6 +199,7 @@ async function checkAlerts(): Promise<void> {
       if (title.includes(queryLower)) {
         notifications.push({
           id: `match-${search.id}-${listing.id}`,
+          type: 'new-match',
           title: `New match: "${search.name}"`,
           body: `${listing.title}${listing.price != null ? ` — $${listing.price}` : ''}`,
           url: listing.url ?? '',
@@ -216,6 +218,7 @@ async function checkAlerts(): Promise<void> {
     if (dropPct >= 5) {
       notifications.push({
         id: `drop-${entry.listingId}-${Date.now()}`,
+        type: 'price-drop',
         title: 'Price drop detected',
         body: `${entry.title}: $${entry.previousPrice} → $${entry.currentPrice} (-${Math.round(dropPct)}%)`,
         url: entry.url ?? '',
@@ -257,10 +260,25 @@ async function checkAlerts(): Promise<void> {
   const urlEntries = Object.entries(mergedUrls);
   const boundedUrls = Object.fromEntries(urlEntries.slice(-200));
 
+  // Append to the notification history the Alerts panel reads (newest kept, capped).
+  const now = Date.now();
+  const existingHistory = (data['mps-notifications'] ?? []) as unknown[];
+  const newHistory = notifications.map((n) => ({
+    id: n.id,
+    type: n.type,
+    title: n.title,
+    body: n.body,
+    url: n.url,
+    timestamp: now,
+    read: false,
+  }));
+  const history = [...newHistory, ...existingHistory].slice(0, 50);
+
   await browser.storage.local.set({
     'mps-last-alert-check': Date.now(),
     'mps-notification-badge-count': badgeCount,
     'mps-notification-urls': boundedUrls,
+    'mps-notifications': history,
     // Price-drop entries are consumed once notified, so clear them to avoid
     // re-notifying the same drop on every subsequent check.
     'mps-price-history': [],
@@ -297,6 +315,7 @@ interface PriceHistoryRecord {
 
 interface AlertNotification {
   id: string;
+  type: 'new-match' | 'price-drop';
   title: string;
   body: string;
   url: string;

--- a/src/content/analysis-runner.ts
+++ b/src/content/analysis-runner.ts
@@ -67,6 +67,7 @@ export async function analyzeListing(
   listing: Listing,
   dataSource: AnalysisDataSource,
   sellerProfile?: Partial<SellerProfile>,
+  searchPosition: number | null = null,
 ): Promise<AnalyzedListing> {
   const fields: AnalysisFields = {};
 
@@ -127,7 +128,7 @@ export async function analyzeListing(
     const heat = calculateHeatScore({
       engagement,
       previousEngagement: previous,
-      searchPosition: null,
+      searchPosition,
       postedDate: listing.parsedDate !== null ? new Date(listing.parsedDate) : null,
     });
     heatScore = heat.score;
@@ -172,11 +173,17 @@ function isWeekend(parsedDate: number | null): boolean {
 export async function analyzeListings(
   listings: Listing[],
   dataSource: AnalysisDataSource,
+  positions?: ReadonlyMap<string, number>,
 ): Promise<AnalyzedListing[]> {
   return Promise.all(
     listings.map(async (listing) => {
       try {
-        return await analyzeListing(listing, dataSource);
+        return await analyzeListing(
+          listing,
+          dataSource,
+          undefined,
+          positions?.get(listing.id) ?? null,
+        );
       } catch {
         return listing as AnalyzedListing;
       }

--- a/src/content/dom-injector.ts
+++ b/src/content/dom-injector.ts
@@ -337,6 +337,9 @@ export class DomInjector {
         badgeEl.className = `mps-badge mps-badge-${badge.type}-${badge.level}`;
         badgeEl.setAttribute("data-mps-badge-type", badge.type);
         badgeEl.setAttribute("data-mps-badge-level", badge.level);
+        // Clickable: opens the matching sidebar panel (handled via delegation).
+        badgeEl.setAttribute("role", "button");
+        badgeEl.style.cursor = "pointer";
         badgeEl.textContent = badge.label;
 
         if (badge.tooltip) {

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -74,6 +74,7 @@ import { ChromeStorageAdapter } from "@/platform/chrome-storage-adapter";
 import type { ISorter } from "@/core/interfaces/sorter.interface";
 import { DataWorkerClient } from "@/content/data-worker-client";
 import { mountComparisonBar } from "@/content/comparison-bar-mount";
+import { showOnboardingIfNeeded } from "@/content/onboarding";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -474,6 +475,29 @@ async function bootstrap(): Promise<void> {
     document.addEventListener("click", onCompareClick, true);
     cleanupFns.push(() => document.removeEventListener("click", onCompareClick, true));
 
+    // Clicking an analysis badge opens the matching sidebar panel.
+    const BADGE_PANEL: Record<string, string> = {
+      trust: "trust",
+      price: "analytics",
+      heat: "heat",
+      forecast: "forecast",
+      image: "images",
+    };
+    const onBadgeClick = (e: MouseEvent): void => {
+      const target = e.target as Element | null;
+      const badge = target?.closest?.(".mps-badge");
+      if (!badge) return;
+      const type = badge.getAttribute("data-mps-badge-type");
+      const panel = type ? BADGE_PANEL[type] : undefined;
+      if (!panel) return;
+      e.preventDefault();
+      e.stopPropagation();
+      eventBus.emit(MPS_EVENTS.SIDEBAR_TOGGLED, { open: true });
+      document.dispatchEvent(new CustomEvent("mps:open-panel", { detail: { panel } }));
+    };
+    document.addEventListener("click", onBadgeClick, true);
+    cleanupFns.push(() => document.removeEventListener("click", onBadgeClick, true));
+
     // 5. Inject UI elements FIRST (before loading settings, so sidebar exists
     //    when loadSettings emits SIDEBAR_TOGGLED to restore open state)
     injector.injectSidebar();
@@ -524,6 +548,13 @@ async function bootstrap(): Promise<void> {
       onCompare: () => eventBus.emit(MPS_EVENTS.SIDEBAR_TOGGLED, { open: true }),
     });
     cleanupFns.push(() => comparisonBar.unmount());
+
+    // Show the first-run onboarding walkthrough (no-op after the first install).
+    showOnboardingIfNeeded()
+      .then((dismiss) => {
+        if (dismiss) cleanupFns.push(dismiss);
+      })
+      .catch(() => {});
 
     // 6. Load persisted settings (may emit SIDEBAR_TOGGLED to reopen sidebar)
     await loadSettings(eventBus);

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -389,6 +389,11 @@ async function bootstrap(): Promise<void> {
               if (card) {
                 injector.injectBadge(card, buildBadges(a));
                 injector.injectCompareButton(card, a.id, comparisonSelection.has(a.id));
+                // Mark cards seen in a previous session, then record this view.
+                if (await persistence.isSeen(a.id)) {
+                  card.setAttribute("data-mps-seen", "true");
+                }
+                void persistence.recordSeen(a);
               }
             } catch (err) {
               console.warn(`${LOG_PREFIX} Badge injection failed for ${a.id}:`, err);

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -140,6 +140,12 @@ function refreshCompareButtons(): void {
 /** All listings the extension has parsed during this page session. */
 const knownListings: Map<string, Listing> = new Map();
 
+/** First-observed result position per listing id (1-based), used for heat scoring. */
+const listingPositions: Map<string, number> = new Map();
+
+/** Running counter assigning each newly observed listing its result position. */
+let positionCounter = 0;
+
 /** Currently active filter configs. */
 let activeFilters: Map<string, Record<string, unknown>> = new Map();
 
@@ -289,6 +295,7 @@ async function bootstrap(): Promise<void> {
             // Track listing
             if (!knownListings.has(listing.id)) {
               knownListings.set(listing.id, listing);
+              listingPositions.set(listing.id, ++positionCounter);
               newListings.push(listing);
             }
           }
@@ -372,7 +379,7 @@ async function bootstrap(): Promise<void> {
       async ({ listings }) => {
         try {
           await persistence.saveListings(listings);
-          const analyzed = await analyzeListings(listings, persistence);
+          const analyzed = await analyzeListings(listings, persistence, listingPositions);
           for (const a of analyzed) {
             knownListings.set(a.id, a);
             try {
@@ -911,6 +918,8 @@ function teardown(): void {
   }
   cleanupFns.length = 0;
   knownListings.clear();
+  listingPositions.clear();
+  positionCounter = 0;
   activeFilters.clear();
 }
 

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -61,6 +61,7 @@ import { createSidebarController, mountSidebar } from "@/content/sidebar-mount";
 import type { AnalyzedListing } from "@/core/models/analyzed-listing";
 import { compareListings } from "@/core/analysis/comparison-engine";
 import type { ComparisonResult } from "@/core/analysis/comparison-engine";
+import { assessOriginality } from "@/core/analysis/image-fingerprint";
 import {
   extractSellerProfile,
   extractDetailEngagement,
@@ -345,18 +346,38 @@ async function bootstrap(): Promise<void> {
           );
           if (dupes.length > 0 && !flags.includes("duplicate")) flags.push("duplicate");
 
+          // Originality from the signals we can derive: uniform/white background,
+          // environmental context (its inverse), multi-angle (multiple images),
+          // and duplicate count. Studio-lighting/recompression aren't detectable.
+          const originality = assessOriginality(
+            {
+              hasWhiteBackground: result.hasUniformBackground,
+              hasStudioLighting: false,
+              hasEnvironmentalContext: !result.hasUniformBackground,
+              isPartOfMultiAngleSet: listing.imageUrls.length > 1,
+              hasHighRecompression: false,
+            },
+            dupes.length,
+          );
+          const originalityScore = originality.score / 100; // store on a 0-1 scale
+
           await persistence.saveImageHash({
             hash: result.hash,
             listingId: listing.id,
             imageUrl: url,
             aiScore: result.aiScore / 100,
-            originalityScore: null,
+            originalityScore,
             flags,
             analyzedAt: new Date().toISOString(),
           });
 
           const current = (knownListings.get(listing.id) as AnalyzedListing | undefined) ?? listing;
-          const updated: AnalyzedListing = { ...current, aiImageScore: result.aiScore, imageFlags: flags };
+          const updated: AnalyzedListing = {
+            ...current,
+            aiImageScore: result.aiScore,
+            imageFlags: flags,
+            originalityScore,
+          };
           knownListings.set(listing.id, updated);
           const card = document.querySelector(`[data-mps-listing-id="${cssEscapeId(listing.id)}"]`);
           if (card) injector.injectBadge(card, buildBadges(updated));

--- a/src/content/persistence.ts
+++ b/src/content/persistence.ts
@@ -30,6 +30,7 @@ import { PriceDataRepository } from "@/data/repositories/price-data.repository";
 import { EngagementRepository } from "@/data/repositories/engagement.repository";
 import { SellerRepository } from "@/data/repositories/seller.repository";
 import { ImageHashRepository } from "@/data/repositories/image-hash.repository";
+import { SeenListingRepository } from "@/data/repositories/seen.repository";
 import type { Listing } from "@/core/models/listing";
 import type {
   ListingRecord,
@@ -37,6 +38,7 @@ import type {
   EngagementSnapshot,
   SellerProfile,
   ImageHash,
+  SeenListing,
 } from "@/data/db-schema";
 
 const LOG_PREFIX = "[MPS:persistence]";
@@ -207,6 +209,7 @@ export class ContentPersistence implements AnalysisDataSource {
   private engagement: EngagementRepository | null = null;
   private sellers: SellerRepository | null = null;
   private imageHashes: ImageHashRepository | null = null;
+  private seen: SeenListingRepository | null = null;
 
   /** Whether IndexedDB initialized successfully. */
   get ready(): boolean {
@@ -233,6 +236,7 @@ export class ContentPersistence implements AnalysisDataSource {
       this.engagement = new EngagementRepository(db);
       this.sellers = new SellerRepository(db);
       this.imageHashes = new ImageHashRepository(db);
+      this.seen = new SeenListingRepository(db);
     } catch (err) {
       console.warn(`${LOG_PREFIX} IndexedDB unavailable; persistence disabled.`, err);
       this.adapter = null;
@@ -415,6 +419,25 @@ export class ContentPersistence implements AnalysisDataSource {
     } catch {
       return null;
     }
+  }
+
+  /** Whether a listing has been seen in a previous observation/session. */
+  async isSeen(listingId: string): Promise<boolean> {
+    if (!this.ready || !this.seen) return false;
+    return this.seen.has(listingId);
+  }
+
+  /** Record a listing as seen (idempotent upsert keyed by listing id). */
+  async recordSeen(listing: Listing): Promise<void> {
+    if (!this.ready || !this.seen) return;
+    const record: SeenListing = {
+      listingId: listing.id,
+      firstSeen: new Date(listing.firstObserved).toISOString(),
+      priceAtFirstSeen: listing.price ?? 0,
+      currentPrice: listing.price,
+      trustScoreAtFirstSeen: null,
+    };
+    await this.seen.save(record);
   }
 
   /** Return the most recently observed listing records (for the history panel). */

--- a/src/content/sidebar-mount.tsx
+++ b/src/content/sidebar-mount.tsx
@@ -25,6 +25,7 @@ import {
   type SavedSearchItem,
   type SettingsState,
   type HistoryEntry,
+  type NotificationFrequency,
 } from "@/ui/sidebar/sidebar-context";
 import type { AnalyzedListing } from "@/core/models/analyzed-listing";
 import type { ComparisonResult } from "@/core/analysis/comparison-engine";
@@ -182,7 +183,12 @@ export function createSidebarController(deps: SidebarMountDeps): SidebarControll
   };
 
   async function loadStored(): Promise<StoredSavedSearch[]> {
-    return storageGet<StoredSavedSearch[]>(SAVED_SEARCHES_KEY, []);
+    const list = await storageGet<StoredSavedSearch[]>(SAVED_SEARCHES_KEY, []);
+    // Backfill `frequency` for searches saved before it was a first-class field.
+    return list.map((s) => ({
+      ...s,
+      frequency: s.frequency ?? (s.notifications?.frequency as NotificationFrequency) ?? "daily",
+    }));
   }
   async function saveStored(list: StoredSavedSearch[]): Promise<StoredSavedSearch[]> {
     await storageSet(SAVED_SEARCHES_KEY, list);
@@ -212,6 +218,7 @@ export function createSidebarController(deps: SidebarMountDeps): SidebarControll
         createdAt: Date.now(),
         lastRunAt: null,
         resultCount: deps.getVisibleCount(),
+        frequency: "daily",
         filters: currentFilterState,
         sortId: deps.getSort().id,
         sortDirection: deps.getSort().direction,
@@ -227,6 +234,21 @@ export function createSidebarController(deps: SidebarMountDeps): SidebarControll
       const list = await loadStored();
       return saveStored(
         list.map((s) => (s.id === id ? { ...s, isPinned: !s.isPinned } : s)),
+      );
+    },
+    async setSavedSearchFrequency(id: string, frequency: NotificationFrequency) {
+      const list = await loadStored();
+      return saveStored(
+        list.map((s) =>
+          s.id === id
+            ? {
+                ...s,
+                frequency,
+                // "manual" disables background alerts; anything else enables them.
+                notifications: { enabled: frequency !== "manual", frequency },
+              }
+            : s,
+        ),
       );
     },
     runSavedSearch(item: SavedSearchItem) {

--- a/src/content/styles.css
+++ b/src/content/styles.css
@@ -381,6 +381,12 @@
   background: var(--mps-color-primary, #0866ff);
 }
 
+/* --- Already-seen listings (subtle dim) --- */
+
+[data-mps-listing-id][data-mps-seen="true"] {
+  opacity: 0.65;
+}
+
 /* ==========================================================================
    Listing Visibility States
    ========================================================================== */

--- a/src/data/repositories/seen.repository.ts
+++ b/src/data/repositories/seen.repository.ts
@@ -1,0 +1,56 @@
+/**
+ * @module data/repositories/seen
+ *
+ * CRUD repository for {@link SeenListing} records in the `seenListings`
+ * IndexedDB object store, used to mark listings the user has already viewed
+ * across sessions.
+ *
+ * @example
+ * ```ts
+ * const repo = new SeenListingRepository(db);
+ * if (await repo.has("12345")) markCardAsSeen();
+ * await repo.save({ listingId: "12345", firstSeen: iso, priceAtFirstSeen: 120, currentPrice: 120, trustScoreAtFirstSeen: null });
+ * ```
+ */
+
+import { IDBPDatabase } from "idb";
+import { STORE_NAMES, SeenListing } from "@/data/db-schema";
+
+/** Repository for persisting and querying {@link SeenListing} records. */
+export class SeenListingRepository {
+  private readonly db: IDBPDatabase;
+
+  constructor(db: IDBPDatabase) {
+    this.db = db;
+  }
+
+  /** Persist (or update) a seen-listing record (keyed by `listingId`). */
+  async save(record: SeenListing): Promise<void> {
+    try {
+      await this.db.put(STORE_NAMES.seenListings, record);
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : "Unknown error";
+      console.warn(`[SeenListingRepository] Failed to save: ${message}`);
+    }
+  }
+
+  /** Return the seen record for a listing, or null if it hasn't been seen. */
+  async getById(listingId: string): Promise<SeenListing | null> {
+    try {
+      const record = await this.db.get(STORE_NAMES.seenListings, listingId);
+      return (record as SeenListing | undefined) ?? null;
+    } catch {
+      return null;
+    }
+  }
+
+  /** Whether a listing has been seen before. */
+  async has(listingId: string): Promise<boolean> {
+    try {
+      const key = await this.db.getKey(STORE_NAMES.seenListings, listingId);
+      return key !== undefined;
+    } catch {
+      return false;
+    }
+  }
+}

--- a/src/ui/sidebar/FilterPanel.tsx
+++ b/src/ui/sidebar/FilterPanel.tsx
@@ -197,6 +197,7 @@ export const FilterPanel: React.FC<{ className?: string }> = ({ className }) => 
             type="text"
             style={inputStyle}
             placeholder="e.g. iPhone, vintage"
+            data-mps-filter-input
             value={filters.keywords}
             onChange={(e) => updateField('keywords', e.target.value)}
           />

--- a/src/ui/sidebar/NotificationPanel.tsx
+++ b/src/ui/sidebar/NotificationPanel.tsx
@@ -5,13 +5,17 @@
  * @module ui/sidebar/NotificationPanel
  */
 
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useEffect } from 'react';
 import { PanelLayout } from '@/design-system/layouts/PanelLayout';
 import { Button } from '@/design-system/primitives/Button';
 import { Badge } from '@/design-system/primitives/Badge';
 import { EmptyState } from '@/design-system/primitives/EmptyState';
+import { browser } from '@/platform/browser';
 
-/** A notification entry for display */
+/** chrome.storage key the background worker appends notification history to. */
+const NOTIFICATIONS_KEY = 'mps-notifications';
+
+/** A notification entry for display (also the persisted shape). */
 interface NotificationEntry {
   id: string;
   type: 'new-match' | 'price-drop';
@@ -44,15 +48,42 @@ function formatTimeAgo(timestamp: number): string {
 export function NotificationPanel({ className }: NotificationPanelProps): React.ReactElement {
   const [notifications, setNotifications] = useState<NotificationEntry[]>([]);
 
-  const markAsRead = useCallback((id: string) => {
-    setNotifications((prev) =>
-      prev.map((n) => (n.id === id ? { ...n, read: true } : n)),
-    );
+  // Load the history the background alert worker persists, newest first.
+  useEffect(() => {
+    let active = true;
+    browser.storage.local
+      .get(NOTIFICATIONS_KEY)
+      .then((stored) => {
+        const list = (stored as Record<string, NotificationEntry[]>)[NOTIFICATIONS_KEY] ?? [];
+        if (active) setNotifications([...list].sort((a, b) => b.timestamp - a.timestamp));
+      })
+      .catch(() => {});
+    return () => {
+      active = false;
+    };
   }, []);
+
+  const persist = useCallback((list: NotificationEntry[]) => {
+    browser.storage.local.set({ [NOTIFICATIONS_KEY]: list }).catch(() => {});
+  }, []);
+
+  const markAsRead = useCallback(
+    (id: string) => {
+      setNotifications((prev) => {
+        const next = prev.map((n) => (n.id === id ? { ...n, read: true } : n));
+        persist(next);
+        return next;
+      });
+    },
+    [persist],
+  );
 
   const clearAll = useCallback(() => {
     setNotifications([]);
-  }, []);
+    persist([]);
+    // Reset the toolbar badge count too.
+    browser.runtime.sendMessage({ action: 'clear-badge' }).catch(() => {});
+  }, [persist]);
 
   const unreadCount = notifications.filter((n) => !n.read).length;
 

--- a/src/ui/sidebar/SavedSearches.tsx
+++ b/src/ui/sidebar/SavedSearches.tsx
@@ -32,6 +32,7 @@ export const SavedSearches: React.FC<SavedSearchesProps> = ({ className }) => {
     addSavedSearch,
     deleteSavedSearch,
     togglePinSavedSearch,
+    setSavedSearchFrequency,
     runSavedSearch,
     exportSavedSearches,
     importSavedSearches,
@@ -173,7 +174,31 @@ export const SavedSearches: React.FC<SavedSearchesProps> = ({ className }) => {
                   {search.resultCount != null && ` \u00B7 ${search.resultCount} results`}
                 </div>
               </div>
-              <div style={{ display: 'flex', gap: 'var(--mps-spacing-xxs)' }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--mps-spacing-xxs)' }}>
+                <select
+                  aria-label="Alert frequency"
+                  title="Alert frequency"
+                  value={search.frequency}
+                  onChange={(e) =>
+                    setSavedSearchFrequency(
+                      search.id,
+                      e.target.value as 'realtime' | 'hourly' | 'daily' | 'manual',
+                    )
+                  }
+                  style={{
+                    fontSize: 'var(--mps-font-size-xs)',
+                    padding: '2px 4px',
+                    border: 'var(--mps-border-width-thin) solid var(--mps-color-border)',
+                    borderRadius: 'var(--mps-radius-sm)',
+                    background: 'var(--mps-color-surface)',
+                    color: 'var(--mps-color-text-primary)',
+                  }}
+                >
+                  <option value="realtime">Realtime</option>
+                  <option value="hourly">Hourly</option>
+                  <option value="daily">Daily</option>
+                  <option value="manual">Manual</option>
+                </select>
                 <Button variant="ghost" size="sm" onClick={() => runSavedSearch(search)}>Load</Button>
                 <Button variant="ghost" size="sm" onClick={() => togglePinSavedSearch(search.id)}>
                   {search.isPinned ? 'Unpin' : 'Pin'}

--- a/src/ui/sidebar/Sidebar.tsx
+++ b/src/ui/sidebar/Sidebar.tsx
@@ -7,7 +7,7 @@
  * @module ui/sidebar/Sidebar
  */
 
-import React, { useState, useCallback, useMemo } from 'react';
+import React, { useState, useCallback, useMemo, useEffect } from 'react';
 import { SidebarLayout } from '@/design-system/layouts/SidebarLayout';
 import { FilterPanel } from '@/ui/sidebar/FilterPanel';
 import { SortPanel } from '@/ui/sidebar/SortPanel';
@@ -19,6 +19,8 @@ import { ComparisonView } from '@/ui/sidebar/ComparisonView';
 import { HeatMap } from '@/ui/sidebar/HeatMap';
 import { SalesForecast } from '@/ui/sidebar/SalesForecast';
 import { ListingHistory } from '@/ui/sidebar/ListingHistory';
+import { NotificationPanel } from '@/ui/sidebar/NotificationPanel';
+import { SelectorHealthPanel } from '@/ui/sidebar/SelectorHealthPanel';
 import { Settings } from '@/ui/sidebar/Settings';
 
 /** Supported sidebar tab identifiers. */
@@ -33,6 +35,8 @@ export type SidebarTabId =
   | 'heat'
   | 'forecast'
   | 'history'
+  | 'notifications'
+  | 'health'
   | 'settings';
 
 /** Tab metadata for rendering the tab bar. */
@@ -54,6 +58,8 @@ const TABS: TabMeta[] = [
   { id: 'heat', label: 'Heat', icon: '\u{1F525}' },
   { id: 'forecast', label: 'Forecast', icon: '\u{1F552}' },
   { id: 'history', label: 'History', icon: '\u{1F4C5}' },
+  { id: 'notifications', label: 'Alerts', icon: '\u{1F514}' },
+  { id: 'health', label: 'Health', icon: '\u{1FA7A}' },
   { id: 'settings', label: 'Settings', icon: '\u2699' },
 ];
 
@@ -92,6 +98,17 @@ export const SidebarTabs: React.FC<{ defaultTab?: SidebarTabId }> = ({
     setActiveTab(tabId);
   }, []);
 
+  // Allow content-script code (e.g. a clicked listing badge) to switch tabs via
+  // a DOM CustomEvent, since it lives outside the React tree.
+  useEffect(() => {
+    const onOpenPanel = (e: Event): void => {
+      const panel = (e as CustomEvent<{ panel?: SidebarTabId }>).detail?.panel;
+      if (panel && TABS.some((t) => t.id === panel)) setActiveTab(panel);
+    };
+    document.addEventListener('mps:open-panel', onOpenPanel);
+    return () => document.removeEventListener('mps:open-panel', onOpenPanel);
+  }, []);
+
   const panelMap = useMemo<Record<SidebarTabId, React.ReactNode>>(
     () => ({
       filters: <FilterPanel />,
@@ -104,6 +121,8 @@ export const SidebarTabs: React.FC<{ defaultTab?: SidebarTabId }> = ({
       heat: <HeatMap />,
       forecast: <SalesForecast />,
       history: <ListingHistory />,
+      notifications: <NotificationPanel />,
+      health: <SelectorHealthPanel />,
       settings: <Settings />,
     }),
     [],

--- a/src/ui/sidebar/sidebar-context.tsx
+++ b/src/ui/sidebar/sidebar-context.tsx
@@ -138,6 +138,9 @@ export interface HistoryEntry {
   viewCount: number;
 }
 
+/** Notification cadence for a saved search's alerts. */
+export type NotificationFrequency = "realtime" | "hourly" | "daily" | "manual";
+
 export interface SavedSearchItem {
   id: string;
   name: string;
@@ -146,6 +149,8 @@ export interface SavedSearchItem {
   createdAt: number;
   lastRunAt: number | null;
   resultCount: number | null;
+  /** Alert cadence; "manual" disables background alerts for this search. */
+  frequency: NotificationFrequency;
 }
 
 export interface SettingsState {
@@ -204,6 +209,7 @@ export interface SidebarController {
   addSavedSearch(name: string): Promise<SavedSearchItem[]>;
   deleteSavedSearch(id: string): Promise<SavedSearchItem[]>;
   togglePinSavedSearch(id: string): Promise<SavedSearchItem[]>;
+  setSavedSearchFrequency(id: string, frequency: NotificationFrequency): Promise<SavedSearchItem[]>;
   runSavedSearch(item: SavedSearchItem): void;
   exportSavedSearches(): Promise<string>;
   importSavedSearches(json: string): Promise<SavedSearchItem[]>;
@@ -324,6 +330,7 @@ export interface SidebarData {
   addSavedSearch: (name: string) => void;
   deleteSavedSearch: (id: string) => void;
   togglePinSavedSearch: (id: string) => void;
+  setSavedSearchFrequency: (id: string, frequency: NotificationFrequency) => void;
   runSavedSearch: (item: SavedSearchItem) => void;
   exportSavedSearches: () => Promise<string>;
   importSavedSearches: (json: string) => void;
@@ -547,6 +554,12 @@ export const SidebarDataProvider: React.FC<SidebarDataProviderProps> = ({
     },
     [controller],
   );
+  const setSavedSearchFrequency = useCallback(
+    (id: string, frequency: NotificationFrequency) => {
+      controller.setSavedSearchFrequency(id, frequency).then(setSavedSearches);
+    },
+    [controller],
+  );
   const runSavedSearch = useCallback(
     (item: SavedSearchItem) => controller.runSavedSearch(item),
     [controller],
@@ -593,6 +606,7 @@ export const SidebarDataProvider: React.FC<SidebarDataProviderProps> = ({
     addSavedSearch,
     deleteSavedSearch,
     togglePinSavedSearch,
+    setSavedSearchFrequency,
     runSavedSearch,
     exportSavedSearches,
     importSavedSearches,


### PR DESCRIPTION
Closes the remaining gaps from the post-merge re-audit. Keeps **typecheck + lint + build green; 580 tests pass**.

## Code wiring
- **Notifications + Selector Health panels** were built but never in the tab map — now mounted as **Alerts** + **Health** tabs (13 panels wired). `NotificationPanel` reads real history the background worker now persists (`mps-notifications`, with type/read state); `SelectorHealthPanel` runs the live check via the existing background round-trip.
- **Badge click → breakdown:** analysis badges are now clickable (role/cursor); clicking opens the matching sidebar panel (trust/price/heat/forecast/image) via a `mps:open-panel` event the tabs listen for.
- **Alt+F** focuses the keyword filter again — the React input now carries `data-mps-filter-input`.
- **Onboarding** runs on first install — `showOnboardingIfNeeded()` is invoked in bootstrap (was orphaned).
- **Heat "search position"** now contributes: the first-observed result position is tracked and passed to `calculateHeatScore` (was hardcoded `null`).
- **Per-saved-search alert frequency** (Realtime/Hourly/Daily/Manual) — a select in Saved Searches drives `notifications.enabled/frequency`; **Manual disables** that search's alerts.
- **Seen tracking** is implemented: new `SeenListingRepository` + `persistence.isSeen/recordSeen`; cards seen in a prior session get a subtle dim (`data-mps-seen`).
- **Image originality** is computed at runtime — `assessOriginality()` is wired from the signals we can derive (uniform/white background, environmental context, multi-angle from image count, duplicate count); persisted on the image hash and the analyzed listing (drives the image-flag `onlyOriginal` filter). Studio-lighting/recompression remain undetectable and are left off.

## Docs (`README.md`, `ARCHITECTURE.md`)
Corrected to match the wired reality: filters 10→9; sidebar 12→13 panels; repositories 6→7; image analysis runs in the **background service worker** (not a Web Worker), data-processing in a Web Worker; "Shadow DOM for UI injection" → scoped/prefixed styles in page DOM (onboarding still uses Shadow DOM); saved searches live in `chrome.storage.local` (not IndexedDB); testing 540+/43 → 580+/49 (+ Content/Plugins rows); per-search notification frequency wording.

## Verification
`pnpm typecheck && lint && test && build` (green). Load `dist/` unpacked on Facebook Marketplace: the **Alerts** + **Health** tabs appear and populate; **Alt+F** focuses the keyword box; clicking a card badge opens the matching panel; previously-seen cards are dimmed; first install shows onboarding.

https://claude.ai/code/session_01AdhVEaVxYJMWA17jNsx2HU

---
_Generated by [Claude Code](https://claude.ai/code/session_01AdhVEaVxYJMWA17jNsx2HU)_